### PR TITLE
Bump version to `v0.3.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2689,7 +2689,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "integration-tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "block-encoding-length",
  "ere-dockerized",
@@ -5986,7 +5986,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "reth-stateless",
  "rkyv",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-ethrex"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6017,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "ere-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.88"
-version = "0.2.0"
+version = "0.3.0"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/bin/block-encoding-length/airbender/Cargo.lock
+++ b/bin/block-encoding-length/airbender/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1305,7 +1305,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",

--- a/bin/block-encoding-length/openvm/Cargo.lock
+++ b/bin/block-encoding-length/openvm/Cargo.lock
@@ -618,7 +618,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",

--- a/bin/block-encoding-length/pico/Cargo.lock
+++ b/bin/block-encoding-length/pico/Cargo.lock
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",

--- a/bin/block-encoding-length/risc0/Cargo.lock
+++ b/bin/block-encoding-length/risc0/Cargo.lock
@@ -812,7 +812,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1604,7 +1604,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",

--- a/bin/block-encoding-length/sp1/Cargo.lock
+++ b/bin/block-encoding-length/sp1/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1348,7 +1348,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",

--- a/bin/block-encoding-length/zisk/Cargo.lock
+++ b/bin/block-encoding-length/zisk/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "block-encoding-length"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -1607,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3386,14 +3386,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rkyv",
 ]
 
 [[package]]
 name = "stateless-validator-ethrex"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ethrex-common",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -2768,14 +2768,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rkyv",
 ]
 
 [[package]]
 name = "stateless-validator-ethrex"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ethrex-common",

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -2681,14 +2681,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "rkyv",
 ]
 
 [[package]]
 name = "stateless-validator-ethrex"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ethrex-common",

--- a/bin/stateless-validator-reth/airbender/Cargo.lock
+++ b/bin/stateless-validator-reth/airbender/Cargo.lock
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3379,14 +3379,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "guest",

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3883,14 +3883,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "guest",

--- a/bin/stateless-validator-reth/pico/Cargo.lock
+++ b/bin/stateless-validator-reth/pico/Cargo.lock
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -4978,14 +4978,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "guest",

--- a/bin/stateless-validator-reth/risc0/Cargo.lock
+++ b/bin/stateless-validator-reth/risc0/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3951,14 +3951,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "guest",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -1505,7 +1505,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3605,14 +3605,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "guest",

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "guest"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "ere-platform-trait",
@@ -3358,14 +3358,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stateless-validator-common"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "stateless-validator-reth"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ere-io",
  "guest",


### PR DESCRIPTION
To be released with #11 which add support of `minisign` for the artifacts.

(rebased #7 on this and no conflict happened, tho might need to run an extra `.github/scripts/cargo-fetch-all.sh`, it should be fine if we merge this first)
