### PR TITLE
Pass password to minisign

### DIFF
--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -128,6 +128,7 @@ jobs:
         env:
           MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
           MINISIGN_PUBLIC_KEY: ${{ secrets.MINISIGN_PUBLIC_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
         run: |
           # Create key files from secrets
           echo "$MINISIGN_SECRET_KEY" > minisign.key
@@ -143,7 +144,7 @@ jobs:
               
               # -S: Sign, -m: file, -s: secret key, -x: output signature, -t: trusted comment
               # We output the .minisig directly into the artifacts folder so it gets released
-              minisign -Sm "$file" -s minisign.key -x "$file.minisig" -t "$filename"
+              echo "$MINISIGN_PASSWORD" | minisign -Sm "$file" -s minisign.key -x "$file.minisig" -t "$filename"
             fi
           done
           


### PR DESCRIPTION
Fix the missing password in `minising` when creating release.

It's working now https://github.com/eth-act/ere-guests/actions/runs/21138841145/job/60788332926?pr=13 