### PR TITLE
Switch to libssz

### DIFF
--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -38,8 +38,6 @@ jobs:
         exclude:
           - guest: stateless-validator-ethrex
             zkvm: airbender
-          - guest: stateless-validator-reth
-            zkvm: airbender
           - guest: stateless-validator-ethrex
             zkvm: openvm
           - guest: stateless-validator-ethrex

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,8 +32,6 @@ jobs:
         exclude:
           - guest: stateless-validator-ethrex
             zkvm: airbender
-          - guest: stateless-validator-reth
-            zkvm: airbender
           - guest: stateless-validator-ethrex
             zkvm: openvm
           - guest: stateless-validator-ethrex

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -79,10 +79,7 @@ jobs:
         run: cargo test --lib --no-fail-fast
 
       # Include the package once the issue is resolved:
-      # - `block-encoding-length` - `ethereum_ssz` is not no_std compatible
       # - `stateless-validator-ethrex` - ethrex is not no_std compatible
-      # - `stateless-validator-reth` - depends on `stateless-validator-common`
-      # - `stateless-validator-common` - sigp deps are not no_std compatible (see https://github.com/eth-act/ere-guests/issues/8)
       - name: Compile to target riscv32imac-unknown-none-elf
         run: |
           cargo build \

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -88,8 +88,8 @@ jobs:
           cargo build \
             --no-default-features \
             --target riscv32imac-unknown-none-elf \
-            --package guest
-            # --include block-encoding-length \
-            # --include stateless-validator-ethrex \
-            # --include stateless-validator-reth \
-            # --include stateless-validator-common
+            --package guest \
+            --package block-encoding-length \
+            --package stateless-validator-reth \
+            --package stateless-validator-common
+            # --package stateless-validator-ethrex

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1072,9 +1072,9 @@ dependencies = [
  "anyhow",
  "ere-io",
  "ere-zkvm-interface",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -1647,36 +1647,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1696,22 +1672,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -2122,57 +2087,6 @@ dependencies = [
  "impl-serde",
  "primitive-types 0.13.1",
  "uint 0.10.0",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c853bd72c9e5787f8aafc3df2907c2ed03cff3150c3acd94e2e53a98ab70a8ab"
-dependencies = [
- "cpufeatures",
- "ring",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -3618,6 +3532,43 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall 0.7.1",
+]
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
 ]
 
 [[package]]
@@ -5973,7 +5924,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -6303,22 +6254,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6357,16 +6292,14 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "rkyv",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -6406,7 +6339,6 @@ dependencies = [
  "anyhow",
  "ere-io",
  "ere-zkvm-interface",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -6417,11 +6349,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -6927,31 +6856,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,15 +84,11 @@ ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v9.0.0"
 ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v9.0.0", default-features = false }
 ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v9.0.0", default-features = false }
 
-# lighthouse
-tree_hash = "0.10.0"
-tree_hash_derive = "0.10.0"
-ssz_types = { version = "0.11", default-features = false }
-typenum = { version = "1.18", default-features = false }
-
 # ssz
-ethereum_ssz = "0.9"
-ethereum_ssz_derive = "0.9"
+libssz = { git = "https://github.com/lambdaclass/libssz", rev = "31786524708d853f5ac8da5bdfd8090a9b99103d", default-features = false, features = ["alloc"] }
+libssz_derive = { package = "libssz-derive", git = "https://github.com/lambdaclass/libssz", rev = "31786524708d853f5ac8da5bdfd8090a9b99103d" }
+libssz_merkle = { package = "libssz-merkle", git = "https://github.com/lambdaclass/libssz", rev = "31786524708d853f5ac8da5bdfd8090a9b99103d", default-features = false, features = ["alloc"] }
+libssz_types = { package = "libssz-types", git = "https://github.com/lambdaclass/libssz", rev = "31786524708d853f5ac8da5bdfd8090a9b99103d", default-features = false, features = ["alloc"] }
 
 # ere
 ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.3.0" }

--- a/bin/block-encoding-length/airbender/Cargo.lock
+++ b/bin/block-encoding-length/airbender/Cargo.lock
@@ -309,7 +309,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -643,9 +643,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "ere-io",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -892,36 +892,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -941,22 +917,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1179,43 +1144,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "git+https://github.com/han0110/ethereum_serde_utils?branch=feature%2Fno-std#2c56c89c4ba9ba6c4d900a516513ce7d679ab47b"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.0"
-source = "git+https://github.com/han0110/ethereum_ssz?branch=feature%2Fno-std#4a5312b676699bb24ff246a0f522db8c05c6212c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.0"
-source = "git+https://github.com/han0110/ethereum_ssz?branch=feature%2Fno-std#4a5312b676699bb24ff246a0f522db8c05c6212c"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1621,6 +1549,24 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2548,7 +2494,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -3241,3 +3187,13 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "ethereum_ssz"
+version = "0.9.0"
+source = "git+https://github.com/han0110/ethereum_ssz?branch=feature%2Fno-std#4a5312b676699bb24ff246a0f522db8c05c6212c"
+
+[[patch.unused]]
+name = "ethereum_ssz_derive"
+version = "0.9.0"
+source = "git+https://github.com/han0110/ethereum_ssz?branch=feature%2Fno-std#4a5312b676699bb24ff246a0f522db8c05c6212c"

--- a/bin/block-encoding-length/airbender/Cargo.lock
+++ b/bin/block-encoding-length/airbender/Cargo.lock
@@ -3187,13 +3187,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "ethereum_ssz"
-version = "0.9.0"
-source = "git+https://github.com/han0110/ethereum_ssz?branch=feature%2Fno-std#4a5312b676699bb24ff246a0f522db8c05c6212c"
-
-[[patch.unused]]
-name = "ethereum_ssz_derive"
-version = "0.9.0"
-source = "git+https://github.com/han0110/ethereum_ssz?branch=feature%2Fno-std#4a5312b676699bb24ff246a0f522db8c05c6212c"

--- a/bin/block-encoding-length/airbender/Cargo.toml
+++ b/bin/block-encoding-length/airbender/Cargo.toml
@@ -16,5 +16,3 @@ block-encoding-length = { path = "../../../crates/block-encoding-length", defaul
 
 [patch.crates-io]
 radium = { git = "https://github.com/han0110/radium", branch = "feature/riscv32ima" }
-ethereum_ssz_derive = { git = "https://github.com/han0110/ethereum_ssz", branch = "feature/no-std" }
-ethereum_ssz = { git = "https://github.com/han0110/ethereum_ssz", branch = "feature/no-std" }

--- a/bin/block-encoding-length/openvm/Cargo.lock
+++ b/bin/block-encoding-length/openvm/Cargo.lock
@@ -309,7 +309,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -643,9 +643,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "ere-io",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -898,36 +898,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -947,22 +923,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1185,46 +1150,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1630,6 +1555,24 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2641,7 +2584,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",

--- a/bin/block-encoding-length/pico/Cargo.lock
+++ b/bin/block-encoding-length/pico/Cargo.lock
@@ -362,7 +362,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -819,9 +819,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "ere-io",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -1257,36 +1257,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1306,22 +1282,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1679,46 +1644,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -2337,6 +2262,24 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4108,7 +4051,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",

--- a/bin/block-encoding-length/risc0/Cargo.lock
+++ b/bin/block-encoding-length/risc0/Cargo.lock
@@ -327,7 +327,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -831,9 +831,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "ere-io",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -1130,36 +1130,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1179,22 +1155,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1442,46 +1407,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1936,6 +1861,24 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3119,7 +3062,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",

--- a/bin/block-encoding-length/sp1/Cargo.lock
+++ b/bin/block-encoding-length/sp1/Cargo.lock
@@ -309,7 +309,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -672,9 +672,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "ere-io",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -927,36 +927,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -976,22 +952,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1214,46 +1179,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1680,6 +1605,24 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2715,7 +2658,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",

--- a/bin/block-encoding-length/zisk/Cargo.lock
+++ b/bin/block-encoding-length/zisk/Cargo.lock
@@ -309,7 +309,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -653,9 +653,9 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "ere-io",
- "ethereum_ssz",
- "ethereum_ssz_derive",
  "guest",
+ "libssz",
+ "libssz-derive",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
  "serde",
@@ -902,36 +902,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -951,22 +927,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1190,46 +1155,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1646,6 +1571,24 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -2569,7 +2512,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -41,44 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-primitives"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 2.0.1",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "indexmap 2.12.1",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.9.2",
- "rapidhash",
- "ruint",
- "rustc-hash",
- "serde",
- "sha3",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
-dependencies = [
- "arrayvec",
- "bytes",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,9 +112,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-r1cs-std",
- "ark-std 0.5.0",
+ "ark-std",
 ]
 
 [[package]]
@@ -164,14 +126,14 @@ dependencies = [
  "ahash",
  "ark-crypto-primitives-macros",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-relations",
- "ark-serialize 0.5.0",
+ "ark-serialize",
  "ark-snark",
- "ark-std 0.5.0",
+ "ark-std",
  "blake2",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "fnv",
  "merlin",
  "sha2",
@@ -195,10 +157,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -211,54 +173,16 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version 0.4.1",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "educe",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -269,57 +193,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -343,11 +222,11 @@ checksum = "88f1d0f3a534bb54188b8dcc104307db6c56cdae574ddc3212aec0625740fc7e"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-poly",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -357,9 +236,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -372,9 +251,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-relations",
- "ark-std 0.5.0",
+ "ark-std",
  "educe",
  "num-bigint 0.4.6",
  "num-integer",
@@ -388,31 +267,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-std",
  "tracing",
  "tracing-subscriber 0.2.25",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -422,9 +280,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.5.0",
+ "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "num-bigint 0.4.6",
 ]
 
@@ -445,30 +303,10 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d368e2848c2d4c129ce7679a7d0d2d612b6a274d3ea6a13bad4445d61b381b88"
 dependencies = [
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-relations",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
+ "ark-serialize",
+ "ark-std",
 ]
 
 [[package]]
@@ -498,17 +336,6 @@ name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -593,7 +420,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -629,7 +456,7 @@ name = "bls12_381"
 version = "0.8.0"
 source = "git+https://github.com/lambdaclass/bls12_381?branch=expose-fp-struct#219174187bd78154cec35b0809799fc2c991a579"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "ff",
  "group",
  "pairing",
@@ -853,18 +680,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "const-hex"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,36 +851,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.111",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1084,22 +875,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.111",
 ]
@@ -1193,15 +973,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
@@ -1242,7 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1281,7 +1052,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -1354,17 +1125,7 @@ name = "ere-platform-trait"
 version = "0.3.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.3.0#ffc0e230cf4387fb22eb755f0fb323b38294520f"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
+ "digest",
 ]
 
 [[package]]
@@ -1396,57 +1157,8 @@ dependencies = [
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.13.1",
- "uint 0.10.0",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "primitive-types",
+ "uint",
 ]
 
 [[package]]
@@ -1543,7 +1255,7 @@ source = "git+https://github.com/lambdaclass/ethrex.git?tag=v9.0.0#e88175e2d49f1
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "bitvec",
  "bls12_381",
  "bytes",
@@ -1636,7 +1348,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
- "digest 0.10.7",
+ "digest",
  "ethereum-types",
  "ethrex-crypto",
  "ethrex-rlp",
@@ -1683,34 +1395,6 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
 ]
 
 [[package]]
@@ -1978,8 +1662,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2012,7 +1694,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2149,15 +1831,6 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
@@ -2171,7 +1844,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
- "rlp 0.6.1",
+ "rlp",
 ]
 
 [[package]]
@@ -2228,15 +1901,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2306,16 +1970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
-]
-
-[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,6 +2034,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,12 +2081,6 @@ dependencies = [
  "clap",
  "escape8259",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2832,16 +2517,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2911,26 +2586,15 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec 0.6.0",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.7.1",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -2957,16 +2621,11 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
- "bit-set",
- "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -2998,12 +2657,6 @@ checksum = "746341cd2357c9a4df2d951522b4a8dd1ef553e543119899ad7bf87e938c8fbe"
 dependencies = [
  "xxhash-rust",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -3052,9 +2705,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "serde",
 ]
 
 [[package]]
@@ -3091,10 +2742,6 @@ name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.4",
- "serde",
-]
 
 [[package]]
 name = "rand_xorshift"
@@ -3103,15 +2750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rapidhash"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -3196,7 +2834,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3226,7 +2864,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "ruint",
- "semver 1.0.27",
+ "semver",
  "serde",
  "tracing",
 ]
@@ -3299,9 +2937,9 @@ dependencies = [
  "anyhow",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-groth16",
- "ark-serialize 0.5.0",
+ "ark-serialize",
  "bytemuck",
  "hex",
  "num-bigint 0.4.6",
@@ -3333,7 +2971,7 @@ dependencies = [
  "borsh",
  "bytemuck",
  "cfg-if",
- "digest 0.10.7",
+ "digest",
  "hex",
  "hex-literal",
  "metal",
@@ -3368,7 +3006,7 @@ dependencies = [
  "risc0-zkp",
  "risc0-zkvm-platform",
  "rrs-lib",
- "semver 1.0.27",
+ "semver",
  "serde",
  "sha2",
  "stability",
@@ -3423,16 +3061,6 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
-name = "rlp"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
@@ -3457,23 +3085,10 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a68df0380e5c9d20ce49534f292a36a7514ae21350726efe1865bdb1fa91d278"
 dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "ark-ff 0.5.0",
  "borsh",
- "bytes",
- "fastrlp 0.3.1",
- "fastrlp 0.4.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "parity-scale-codec",
- "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
  "rand 0.9.2",
- "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -3499,53 +3114,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver 1.0.27",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -3611,30 +3183,12 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 dependencies = [
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -3714,7 +3268,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -3727,7 +3281,7 @@ source = "git+https://github.com/risc0/RustCrypto-hashes?tag=sha2-v0.10.9-riscze
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3736,18 +3290,8 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
-]
-
-[[package]]
-name = "sha3-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
-dependencies = [
- "cc",
- "cfg-if",
 ]
 
 [[package]]
@@ -3771,7 +3315,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3862,22 +3406,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3898,16 +3426,14 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "rkyv",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -4027,19 +3553,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "thiserror"
@@ -4269,53 +3782,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -4398,15 +3868,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/bin/stateless-validator-ethrex/risc0/Cargo.toml
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.toml
@@ -30,7 +30,6 @@ p256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "p25
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "c-kzg/v2.1.1-risczero.0" }
 substrate-bn = { git = "https://github.com/risc0/paritytech-bn", tag = "v0.6.0-risczero.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 # These precompiles require the "unstable" risc0 feature which is not suited
 # for production environments.

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -41,44 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-primitives"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 2.1.1",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "indexmap 2.12.1",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.9.2",
- "rapidhash",
- "ruint",
- "rustc-hash",
- "serde",
- "sha3",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
-dependencies = [
- "arrayvec",
- "bytes",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,8 +112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -161,10 +123,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -177,54 +139,16 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version 0.4.1",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "educe",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -235,57 +159,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -308,33 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -344,9 +202,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.5.0",
+ "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "num-bigint 0.4.6",
 ]
 
@@ -363,32 +221,12 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -408,17 +246,6 @@ name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -474,12 +301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,12 +340,12 @@ version = "0.8.0"
 source = "git+https://github.com/lambdaclass/bls12_381-patch/?branch=expose-fp-struct#f2242f78b2b5fc10d9168a810c04ab8728ac6804"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
  "ff",
  "group",
  "hex",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "sp1-lib",
  "subtle",
 ]
@@ -680,18 +501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "const-hex"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,15 +537,6 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -833,7 +633,7 @@ version = "0.5.5"
 source = "git+https://github.com/sp1-patches/RustCrypto-bigint?tag=patch-0.5.5-sp1-4.0.0#d421029772fb604022defd4cae5fffb269ad5155"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -850,36 +650,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.111",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -898,22 +674,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.111",
 ]
@@ -952,32 +717,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl 2.1.1",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -986,34 +731,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
  "unicode-xid",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case 0.10.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.111",
- "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1051,7 +773,7 @@ version = "0.16.9"
 source = "git+https://github.com/sp1-patches/signatures?tag=patch-16.9-sp1-4.1.0#1880299a48fe7ef249edaa616fd411239fb5daf1"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1084,14 +806,14 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "hkdf",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1145,17 +867,7 @@ name = "ere-platform-trait"
 version = "0.3.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.3.0#ffc0e230cf4387fb22eb755f0fb323b38294520f"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
+ "digest",
 ]
 
 [[package]]
@@ -1187,57 +899,8 @@ dependencies = [
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.13.1",
- "uint 0.10.0",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "primitive-types",
+ "uint",
 ]
 
 [[package]]
@@ -1333,12 +996,12 @@ source = "git+https://github.com/lambdaclass/ethrex.git?tag=v9.0.0#e88175e2d49f1
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "bitvec",
  "bls12_381",
  "bytes",
  "datatest-stable",
- "derive_more 1.0.0",
+ "derive_more",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-rlp",
@@ -1426,7 +1089,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
- "digest 0.10.7",
+ "digest",
  "ethereum-types",
  "ethrex-crypto",
  "ethrex-rlp",
@@ -1449,7 +1112,7 @@ source = "git+https://github.com/lambdaclass/ethrex.git?tag=v9.0.0#e88175e2d49f1
 dependencies = [
  "bincode",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "dyn-clone",
  "ethereum-types",
  "ethrex-common",
@@ -1476,34 +1139,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1512,7 +1147,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1544,7 +1179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1674,7 +1309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1735,8 +1370,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1772,7 +1405,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1909,15 +1542,6 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
@@ -1931,7 +1555,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
- "rlp 0.6.1",
+ "rlp",
 ]
 
 [[package]]
@@ -1982,15 +1606,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2060,16 +1675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
-]
-
-[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,8 +1695,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
 dependencies = [
  "lambdaworks-math",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "serde",
  "sha2",
  "sha3",
@@ -2106,7 +1711,7 @@ dependencies = [
  "getrandom 0.2.16",
  "num-bigint 0.4.6",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "serde",
  "serde_json",
@@ -2134,6 +1739,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,12 +1786,6 @@ dependencies = [
  "clap",
  "escape8259",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2305,7 +1941,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2344,7 +1979,7 @@ dependencies = [
  "p3-mds",
  "p3-poseidon2",
  "p3-symmetric",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2371,7 +2006,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "p3-util",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2385,7 +2020,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -2408,7 +2043,7 @@ dependencies = [
  "p3-matrix",
  "p3-symmetric",
  "p3-util",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2421,7 +2056,7 @@ dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2504,16 +2139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,26 +2194,15 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec 0.6.0",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.7.1",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -2607,25 +2221,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
 ]
 
 [[package]]
@@ -2656,12 +2251,6 @@ checksum = "746341cd2357c9a4df2d951522b4a8dd1ef553e543119899ad7bf87e938c8fbe"
 dependencies = [
  "xxhash-rust",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -2700,19 +2289,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
- "serde",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2722,17 +2300,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2742,34 +2310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
- "serde",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rapidhash"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -2853,7 +2393,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2888,16 +2428,6 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
-name = "rlp"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
@@ -2905,40 +2435,6 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
-
-[[package]]
-name = "ruint"
-version = "1.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
-dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "ark-ff 0.5.0",
- "bytes",
- "fastrlp 0.3.1",
- "fastrlp 0.4.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "parity-scale-codec",
- "primitive-types 0.12.2",
- "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
- "rlp 0.5.2",
- "ruint-macro",
- "serde_core",
- "valuable",
- "zeroize",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
@@ -2953,53 +2449,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver 1.0.27",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -3061,30 +2514,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -3164,7 +2593,7 @@ version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a72d8216842fdd57820dc78d840bef99248e35fb2554ff923319e60f2d686b"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -3177,7 +2606,7 @@ source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3185,18 +2614,8 @@ name = "sha3"
 version = "0.10.8"
 source = "git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha3-0.10.8-sp1-4.0.0#8f6d303c0861ba7e5adcc36207c0f41fe5edaabc"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
-]
-
-[[package]]
-name = "sha3-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
-dependencies = [
- "cc",
- "cfg-if",
 ]
 
 [[package]]
@@ -3220,8 +2639,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -3291,7 +2710,7 @@ dependencies = [
  "getrandom 0.3.4",
  "lazy_static",
  "libm",
- "rand 0.8.5",
+ "rand",
  "sha2",
  "sp1-lib",
  "sp1-primitives",
@@ -3307,7 +2726,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "sp1-lib",
  "subtle",
 ]
@@ -3329,22 +2748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,16 +2758,14 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "rkyv",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -3435,7 +2836,7 @@ dependencies = [
  "crunchy",
  "lazy_static",
  "num-bigint 0.4.6",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "sp1-lib",
 ]
@@ -3484,19 +2885,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "thiserror"
@@ -3708,53 +3096,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -3767,12 +3112,6 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -3837,15 +3176,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/bin/stateless-validator-ethrex/sp1/Cargo.toml
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.toml
@@ -24,7 +24,6 @@ p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p2
 ecdsa = { git = "https://github.com/sp1-patches/signatures", tag = "patch-16.9-sp1-4.1.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-5.0.0" }
 substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-5.0.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [patch."https://github.com/lambdaclass/bls12_381"]
 bls12_381 = { git = "https://github.com/lambdaclass/bls12_381-patch/", branch = "expose-fp-struct" }

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -41,44 +41,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "alloy-primitives"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a0fb18dd5fb43ec5f0f6a20be1ce0287c79825827de5744afaa6c957737c33"
-dependencies = [
- "alloy-rlp",
- "bytes",
- "cfg-if",
- "const-hex",
- "derive_more 2.1.1",
- "foldhash 0.2.0",
- "hashbrown 0.16.1",
- "indexmap 2.12.1",
- "itoa",
- "k256",
- "keccak-asm",
- "paste",
- "proptest",
- "rand 0.9.2",
- "rapidhash",
- "ruint",
- "rustc-hash",
- "serde",
- "sha3",
- "tiny-keccak",
-]
-
-[[package]]
-name = "alloy-rlp"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f70d83b765fdc080dbcd4f4db70d8d23fe4761f2f02ebfa9146b833900634b4"
-dependencies = [
- "arrayvec",
- "bytes",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,8 +112,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-std",
 ]
 
 [[package]]
@@ -161,10 +123,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
@@ -177,54 +139,16 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
-dependencies = [
- "ark-ff-asm 0.3.0",
- "ark-ff-macros 0.3.0",
- "ark-serialize 0.3.0",
- "ark-std 0.3.0",
- "derivative",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version 0.3.3",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
-dependencies = [
- "ark-ff-asm 0.4.2",
- "ark-ff-macros 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "digest 0.10.7",
- "itertools 0.10.5",
- "num-bigint 0.4.6",
- "num-traits",
- "paste",
- "rustc_version 0.4.1",
- "zeroize",
-]
-
-[[package]]
-name = "ark-ff"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm 0.5.0",
- "ark-ff-macros 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff-asm",
+ "ark-ff-macros",
+ "ark-serialize",
+ "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "educe",
  "itertools 0.13.0",
  "num-bigint 0.4.6",
@@ -235,57 +159,12 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ark-ff-macros"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
-dependencies = [
- "num-bigint 0.4.6",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -308,33 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff",
+ "ark-serialize",
+ "ark-std",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
-dependencies = [
- "ark-std 0.3.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "ark-serialize"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
-dependencies = [
- "ark-std 0.4.0",
- "digest 0.10.7",
- "num-bigint 0.4.6",
 ]
 
 [[package]]
@@ -344,9 +202,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
  "ark-serialize-derive",
- "ark-std 0.5.0",
+ "ark-std",
  "arrayvec",
- "digest 0.10.7",
+ "digest",
  "num-bigint 0.4.6",
 ]
 
@@ -363,32 +221,12 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
-dependencies = [
- "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -408,17 +246,6 @@ name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -494,12 +321,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
-
-[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,11 +359,11 @@ name = "bls12_381"
 version = "0.8.0"
 source = "git+https://github.com/lambdaclass/bls12_381?branch=expose-fp-struct#219174187bd78154cec35b0809799fc2c991a579"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "ff",
  "group",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -683,18 +504,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
-name = "const-hex"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bb320cac8a0750d7f25280aa97b09c26edfe161164238ecbbb31092b079e735"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "proptest",
- "serde_core",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,15 +540,6 @@ name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -837,7 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -854,36 +654,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.111",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -902,22 +678,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.111",
 ]
@@ -956,32 +721,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
 dependencies = [
- "derive_more-impl 1.0.0",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl 2.1.1",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -990,34 +735,11 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
  "unicode-xid",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case 0.10.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.111",
- "unicode-xid",
-]
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1056,7 +778,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1089,13 +811,13 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -1140,7 +862,7 @@ name = "ere-platform-trait"
 version = "0.3.0"
 source = "git+https://github.com/eth-act/ere?tag=v0.3.0#ffc0e230cf4387fb22eb755f0fb323b38294520f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1151,16 +873,6 @@ dependencies = [
  "ere-platform-trait",
  "fnv",
  "ziskos",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -1192,57 +904,8 @@ dependencies = [
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types 0.13.1",
- "uint 0.10.0",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
+ "primitive-types",
+ "uint",
 ]
 
 [[package]]
@@ -1338,12 +1001,12 @@ source = "git+https://github.com/lambdaclass/ethrex.git?tag=v9.0.0#e88175e2d49f1
 dependencies = [
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff",
  "bitvec",
  "bls12_381",
  "bytes",
  "datatest-stable",
- "derive_more 1.0.0",
+ "derive_more",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-rlp",
@@ -1432,7 +1095,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "crossbeam",
- "digest 0.10.7",
+ "digest",
  "ethereum-types",
  "ethrex-crypto",
  "ethrex-rlp",
@@ -1455,7 +1118,7 @@ source = "git+https://github.com/lambdaclass/ethrex.git?tag=v9.0.0#e88175e2d49f1
 dependencies = [
  "bincode 1.3.3",
  "bytes",
- "derive_more 1.0.0",
+ "derive_more",
  "dyn-clone",
  "ethereum-types",
  "ethrex-common",
@@ -1482,34 +1145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fastrlp"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
-name = "fastrlp"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "bytes",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,7 +1153,7 @@ dependencies = [
  "bitvec",
  "byteorder",
  "ff_derive",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1550,7 +1185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1662,25 +1297,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi",
- "wasip2",
-]
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1741,8 +1364,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1769,7 +1390,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -1906,15 +1527,6 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
-name = "impl-codec"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
@@ -1928,7 +1540,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54ed8ad1f3877f7e775b8cbf30ed1bd3209a95401817f19a0eb4402d13f8cf90"
 dependencies = [
- "rlp 0.6.1",
+ "rlp",
 ]
 
 [[package]]
@@ -1979,15 +1591,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -2055,16 +1658,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keccak-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
-dependencies = [
- "digest 0.10.7",
- "sha3-asm",
-]
-
-[[package]]
 name = "kzg-rs"
 version = "0.2.7"
 source = "git+https://github.com/0xPolygonHermez/zisk-patch-kzg/?tag=patch-0.2.7-zisk-0.15.0#7b29934400c0af21a63635544e72a4621f88e603"
@@ -2085,8 +1678,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b1a1c1102a5a7fbbda117b79fb3a01e033459c738a3c1642269603484fd1c1"
 dependencies = [
  "lambdaworks-math",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "serde",
  "sha2",
  "sha3",
@@ -2098,10 +1691,10 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "018a95aa873eb49896a858dee0d925c33f3978d073c64b08dd4f2c9b35a017c6"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom",
  "num-bigint 0.4.6",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "rayon",
  "serde",
  "serde_json",
@@ -2134,6 +1727,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
+
+[[package]]
 name = "libtest-mimic"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2144,12 +1774,6 @@ dependencies = [
  "clap",
  "escape8259",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2305,7 +1929,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2343,7 +1966,7 @@ dependencies = [
  "p3-mds",
  "p3-poseidon2",
  "p3-symmetric",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2370,7 +1993,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "p3-util",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2384,7 +2007,7 @@ dependencies = [
  "p3-field",
  "p3-maybe-rayon",
  "p3-util",
- "rand 0.8.5",
+ "rand",
  "serde",
  "tracing",
 ]
@@ -2407,7 +2030,7 @@ dependencies = [
  "p3-matrix",
  "p3-symmetric",
  "p3-util",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -2420,7 +2043,7 @@ dependencies = [
  "p3-field",
  "p3-mds",
  "p3-symmetric",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -2503,16 +2126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
-name = "pest"
-version = "2.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9eb05c21a464ea704b53158d358a31e6425db2f63a1a7312268b05fe2b75f7"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,26 +2182,15 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash",
- "impl-codec 0.6.0",
- "uint 0.9.5",
-]
-
-[[package]]
-name = "primitive-types"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.7.1",
+ "impl-codec",
  "impl-rlp",
  "impl-serde",
- "uint 0.10.0",
+ "uint",
 ]
 
 [[package]]
@@ -2607,25 +2209,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
-dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
- "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_xorshift",
- "regex-syntax",
- "rusty-fork",
- "tempfile",
- "unarray",
 ]
 
 [[package]]
@@ -2658,12 +2241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,12 +2248,6 @@ checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
@@ -2700,19 +2271,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
- "serde",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2722,17 +2282,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core",
 ]
 
 [[package]]
@@ -2741,35 +2291,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
- "serde",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
-dependencies = [
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rapidhash"
-version = "4.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
-dependencies = [
- "rustversion",
+ "getrandom",
 ]
 
 [[package]]
@@ -2854,7 +2376,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2889,16 +2411,6 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
-dependencies = [
- "bytes",
- "rustc-hex",
-]
-
-[[package]]
-name = "rlp"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
@@ -2906,40 +2418,6 @@ dependencies = [
  "bytes",
  "rustc-hex",
 ]
-
-[[package]]
-name = "ruint"
-version = "1.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
-dependencies = [
- "alloy-rlp",
- "ark-ff 0.3.0",
- "ark-ff 0.4.2",
- "ark-ff 0.5.0",
- "bytes",
- "fastrlp 0.3.1",
- "fastrlp 0.4.0",
- "num-bigint 0.4.6",
- "num-integer",
- "num-traits",
- "parity-scale-codec",
- "primitive-types 0.12.2",
- "proptest",
- "rand 0.8.5",
- "rand 0.9.2",
- "rlp 0.5.2",
- "ruint-macro",
- "serde_core",
- "valuable",
- "zeroize",
-]
-
-[[package]]
-name = "ruint-macro"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-hash"
@@ -2954,53 +2432,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
-name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
-dependencies = [
- "semver 1.0.27",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
-dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -3062,30 +2497,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "semver"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9900206b54a3527fdc7b8a938bffd94a568bac4f4aa8113b209df75a09c0dec2"
-dependencies = [
- "pest",
 ]
 
 [[package]]
@@ -3165,7 +2576,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.111",
@@ -3178,7 +2589,7 @@ source = "git+https://github.com/0xPolygonHermez/zisk-patch-hashes.git?tag=patch
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -3186,18 +2597,8 @@ name = "sha3"
 version = "0.10.8"
 source = "git+https://github.com/0xPolygonHermez/zisk-patch-hashes.git?tag=patch-sha3-0.10.8-zisk-0.15.0#08098df5827b672d604e2dc440446b86064b99f2"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
-]
-
-[[package]]
-name = "sha3-asm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
-dependencies = [
- "cc",
- "cfg-if",
 ]
 
 [[package]]
@@ -3221,8 +2622,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -3289,7 +2690,7 @@ dependencies = [
  "ff",
  "group",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "sp1-lib",
  "subtle",
 ]
@@ -3311,22 +2712,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,16 +2722,14 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "rkyv",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -3414,7 +2797,7 @@ dependencies = [
  "byteorder",
  "crunchy",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
 ]
 
@@ -3462,19 +2845,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
-dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix",
- "windows-sys",
-]
 
 [[package]]
 name = "thiserror"
@@ -3686,53 +3056,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "uint"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
-dependencies = [
- "byteorder",
- "crunchy",
- "hex",
- "static_assertions",
-]
 
 [[package]]
 name = "uint"
@@ -3745,12 +3072,6 @@ dependencies = [
  "hex",
  "static_assertions",
 ]
-
-[[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"
@@ -3829,15 +3150,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3852,15 +3164,6 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
-dependencies = [
- "wit-bindgen",
-]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4002,12 +3305,6 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -4154,13 +3451,13 @@ source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.15.0#b3ca745b80
 dependencies = [
  "bincode 2.0.1",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom",
  "lazy_static",
  "lib-c",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
  "static_assertions",
  "tiny-keccak",

--- a/bin/stateless-validator-ethrex/zisk/Cargo.toml
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.toml
@@ -23,7 +23,6 @@ substrate-bn = { git = "https://github.com/0xPolygonHermez/zisk-patch-bn.git", t
 sp1_bls12_381 = { git = "https://github.com/0xPolygonHermez/zisk-patch-bls12-381", tag = "patch-0.8.0-zisk-0.15.0" }
 tiny-keccak = { git = "https://github.com/0xPolygonHermez/zisk-patch-tiny-keccak/", tag = "patch-2.0.2-zisk-0.15.0" }
 kzg-rs = { git = "https://github.com/0xPolygonHermez/zisk-patch-kzg/", tag = "patch-0.2.7-zisk-0.15.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/airbender/Cargo.lock
+++ b/bin/stateless-validator-reth/airbender/Cargo.lock
@@ -414,7 +414,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1059,36 +1059,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1108,22 +1084,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1368,55 +1333,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1986,6 +1902,43 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3442,7 +3395,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -3537,22 +3490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,15 +3526,13 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -3612,7 +3547,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "ere-io",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -3623,11 +3557,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -3886,31 +3817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/airbender/Cargo.toml
+++ b/bin/stateless-validator-reth/airbender/Cargo.toml
@@ -23,7 +23,6 @@ stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", 
 
 [patch.crates-io]
 radium = { git = "https://github.com/han0110/radium", branch = "feature/riscv32ima" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -414,7 +414,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1114,36 +1114,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1163,22 +1139,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1423,55 +1388,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -2103,6 +2019,43 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3927,7 +3880,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -4028,22 +3981,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,15 +4017,13 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -4103,7 +4038,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "ere-io",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -4114,11 +4048,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -4396,31 +4327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -64,9 +64,6 @@ openvm-rv32im-guest = { git = "https://github.com/openvm-org//openvm.git", tag =
 openvm-sha2 = { git = "https://github.com/openvm-org//openvm.git", tag = "v1.4.2" }
 openvm-sha256-guest = { git = "https://github.com/openvm-org//openvm.git", tag = "v1.4.2" }
 
-[patch.crates-io]
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
-
 [profile.release]
 codegen-units = 1
 lto = "fat"

--- a/bin/stateless-validator-reth/pico/Cargo.lock
+++ b/bin/stateless-validator-reth/pico/Cargo.lock
@@ -449,7 +449,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1428,36 +1428,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1477,22 +1453,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1874,55 +1839,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -2714,6 +2630,43 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4956,7 +4909,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -5068,22 +5021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,15 +5057,13 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -5143,7 +5078,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "ere-io",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -5154,11 +5088,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -5572,31 +5503,6 @@ checksum = "1ad61aed86bc3faea4300c7aee358b4c6d0c8d6ccc36524c96e4c92ccf26e77e"
 dependencies = [
  "num-integer",
  "strength_reduce",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/pico/Cargo.toml
+++ b/bin/stateless-validator-reth/pico/Cargo.toml
@@ -29,7 +29,6 @@ sha3 = { git = "https://github.com/brevis-network/hashes", tag = "pico-patch-v1.
 curve25519-dalek = { git = "https://github.com/brevis-network/curve25519-dalek", tag = "pico-patch-v1.0.1-curve25519-dalek-v4.1.3" }
 ecdsa-core = { git = "https://github.com/brevis-network/signatures", tag = "pico-patch-v1.0.1-ecdsa-0.16.9", package = "ecdsa" }
 substrate-bn = { git = "https://github.com/brevis-network/bn", tag = "pico-patch-v1.0.1-bn-v0.6.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/risc0/Cargo.lock
+++ b/bin/stateless-validator-reth/risc0/Cargo.lock
@@ -415,7 +415,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1221,36 +1221,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1270,22 +1246,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1555,55 +1520,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -2213,6 +2129,43 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3971,7 +3924,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -4065,22 +4018,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,15 +4064,13 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -4150,7 +4085,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "ere-io",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -4161,11 +4095,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -4445,31 +4376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
  "tracing-core",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/risc0/Cargo.toml
+++ b/bin/stateless-validator-reth/risc0/Cargo.toml
@@ -38,7 +38,6 @@ p256 = { git = "https://github.com/risc0/RustCrypto-elliptic-curves", tag = "p25
 substrate-bn = { git = "https://github.com/risc0/paritytech-bn", tag = "v0.6.0-risczero.0" }
 crypto-bigint = { git = "https://github.com/risc0/RustCrypto-crypto-bigint", tag = "v0.5.5-risczero.0" }
 c-kzg = { git = "https://github.com/risc0/c-kzg-4844", tag = "v2.1.5-risczero.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -414,7 +414,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1107,36 +1107,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1156,22 +1132,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1416,55 +1381,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -2059,6 +1975,43 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3622,7 +3575,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -3764,22 +3717,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,15 +3753,13 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -3839,7 +3774,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "ere-io",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -3850,11 +3784,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -4116,31 +4047,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -27,7 +27,6 @@ k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k2
 p256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-p256-13.2-sp1-5.0.0" }
 substrate-bn = { git = "https://github.com/sp1-patches/bn", tag = "patch-0.6.0-sp1-5.0.0" }
 ecdsa = { git = "https://github.com/sp1-patches/signatures", tag = "patch-16.9-sp1-4.1.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [profile.release]
 codegen-units = 1

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -414,7 +414,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397406cf04b11ca2a48e6f81804c70af3f40a36abf648e11dc7416043eb0834d"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -1057,36 +1057,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.116",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1106,22 +1082,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.116",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core",
  "quote",
  "syn 2.0.116",
 ]
@@ -1367,55 +1332,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
-]
-
-[[package]]
-name = "ethereum_hashing"
-version = "0.7.0"
-source = "git+https://github.com/jsign/ethereum_hashing?rev=08c88633b700d7447ef840d19ce7b369c44311de#08c88633b700d7447ef840d19ce7b369c44311de"
-dependencies = [
- "cpufeatures",
- "sha2",
-]
-
-[[package]]
-name = "ethereum_serde_utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dc1355dbb41fbbd34ec28d4fb2a57d9a70c67ac3c19f6a5ca4d4a176b9e997a"
-dependencies = [
- "alloy-primitives",
- "hex",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
-name = "ethereum_ssz"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcddb2554d19cde19b099fadddde576929d7a4d0c1cd3512d1fd95cf174375c"
-dependencies = [
- "alloy-primitives",
- "ethereum_serde_utils",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "ethereum_ssz_derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a657b6b3b7e153637dc6bdc6566ad9279d9ee11a15b12cfb24a2e04360637e9f"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]
@@ -1884,15 +1800,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1989,6 +1896,43 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libssz"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "libssz-derive"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-types"
+version = "0.1.0"
+source = "git+https://github.com/lambdaclass/libssz?rev=31786524708d853f5ac8da5bdfd8090a9b99103d#31786524708d853f5ac8da5bdfd8090a9b99103d"
+dependencies = [
+ "libssz",
+ "libssz-merkle",
+ "smallvec",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -3441,7 +3385,7 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.116",
@@ -3534,22 +3478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ssz_types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b55bedc9a18ed2860a46d6beb4f4082416ee1d60be0cc364cebdcdddc7afd4"
-dependencies = [
- "ethereum_serde_utils",
- "ethereum_ssz",
- "itertools 0.13.0",
- "serde",
- "serde_derive",
- "smallvec",
- "tree_hash",
- "typenum",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3586,15 +3514,13 @@ name = "stateless-validator-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "ethereum_ssz",
- "ethereum_ssz_derive",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
- "tree_hash",
- "tree_hash_derive",
- "typenum",
 ]
 
 [[package]]
@@ -3609,7 +3535,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "anyhow",
  "ere-io",
- "ethereum_ssz",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -3620,11 +3545,8 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "ssz_types",
  "stateless",
  "stateless-validator-common",
- "tree_hash",
- "tree_hash_derive",
  "tries",
 ]
 
@@ -3891,31 +3813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tree_hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee44f4cef85f88b4dea21c0b1f58320bdf35715cf56d840969487cff00613321"
-dependencies = [
- "alloy-primitives",
- "ethereum_hashing",
- "ethereum_ssz",
- "smallvec",
- "typenum",
-]
-
-[[package]]
-name = "tree_hash_derive"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bee2ea1551f90040ab0e34b6fb7f2fa3bad8acc925837ac654f2c78a13e3089"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -31,7 +31,6 @@ ark-ff = { git = "https://github.com/0xPolygonHermez/zisk-patch-ark-algebra.git"
 ark-bn254 = { git = "https://github.com/0xPolygonHermez/zisk-patch-ark-algebra.git", tag = "patch-0.5.0-zisk-0.15.0" }
 ark-serialize = { git = "https://github.com/0xPolygonHermez/zisk-patch-ark-algebra.git", tag = "patch-0.5.0-zisk-0.15.0" }
 aurora-engine-modexp = { git = "https://github.com/0xPolygonHermez/zisk-patch-modexp.git", tag = "patch-1.2.0-zisk-0.15.0" }
-ethereum_hashing = { git = "https://github.com/jsign/ethereum_hashing", rev = "08c88633b700d7447ef840d19ce7b369c44311de" }
 
 [profile.release]
 codegen-units = 1

--- a/crates/block-encoding-length/Cargo.toml
+++ b/crates/block-encoding-length/Cargo.toml
@@ -23,8 +23,8 @@ reth-ethereum-primitives = { workspace = true, features = ["serde", "serde-binco
 reth-primitives-traits.workspace = true
 
 # ssz
-ethereum_ssz.workspace = true
-ethereum_ssz_derive.workspace = true
+libssz.workspace = true
+libssz_derive.workspace = true
 
 # ere
 ere-io = { workspace = true, features = ["bincode"] }

--- a/crates/block-encoding-length/src/guest.rs
+++ b/crates/block-encoding-length/src/guest.rs
@@ -3,10 +3,10 @@
 use core::ops::Deref;
 
 use ere_io::serde::{IoSerde, bincode::BincodeLegacy};
+use libssz::SszEncode;
 use reth_ethereum_primitives::Block;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
-use ssz::Encode;
 
 #[rustfmt::skip]
 pub use guest::*;
@@ -74,7 +74,7 @@ impl Guest for BlockEncodingLengthGuest {
 
                 P::cycle_scope("block_encoding_length_calculation", || {
                     for _ in 0..input.loop_count {
-                        block.ssz_bytes_len();
+                        block.encoded_len();
                     }
                 });
             }

--- a/crates/block-encoding-length/src/guest/block_ssz.rs
+++ b/crates/block-encoding-length/src/guest/block_ssz.rs
@@ -310,11 +310,7 @@ impl From<alloy_consensus::transaction::TxEip1559> for TxEip1559 {
             max_priority_fee_per_gas: value.max_priority_fee_per_gas,
             to: tx_kind_to_address(value.to),
             value: value.value.to_le_bytes(),
-            access_list: value
-                .access_list
-                .iter()
-                .map(AccessListItem::from)
-                .collect(),
+            access_list: value.access_list.iter().map(AccessListItem::from).collect(),
             input: value.input.to_vec(),
         }
     }
@@ -362,11 +358,7 @@ impl From<alloy_consensus::transaction::TxEip4844> for TxEip4844 {
             max_priority_fee_per_gas: value.max_priority_fee_per_gas,
             to: value.to.into(),
             value: value.value.to_le_bytes(),
-            access_list: value
-                .access_list
-                .iter()
-                .map(AccessListItem::from)
-                .collect(),
+            access_list: value.access_list.iter().map(AccessListItem::from).collect(),
             blob_versioned_hashes: value
                 .blob_versioned_hashes
                 .into_iter()
@@ -400,11 +392,7 @@ impl From<alloy_consensus::transaction::TxEip2930> for TxEip2930 {
             gas_limit: value.gas_limit,
             to: tx_kind_to_address(value.to),
             value: value.value.to_le_bytes(),
-            access_list: value
-                .access_list
-                .iter()
-                .map(AccessListItem::from)
-                .collect(),
+            access_list: value.access_list.iter().map(AccessListItem::from).collect(),
             input: value.input.to_vec(),
         }
     }
@@ -435,11 +423,7 @@ impl From<alloy_consensus::transaction::TxEip7702> for TxEip7702 {
             max_priority_fee_per_gas: value.max_priority_fee_per_gas,
             to: value.to.into(),
             value: value.value.to_le_bytes(),
-            access_list: value
-                .access_list
-                .iter()
-                .map(AccessListItem::from)
-                .collect(),
+            access_list: value.access_list.iter().map(AccessListItem::from).collect(),
             authorization_list: value
                 .authorization_list
                 .into_iter()

--- a/crates/block-encoding-length/src/guest/block_ssz.rs
+++ b/crates/block-encoding-length/src/guest/block_ssz.rs
@@ -1,18 +1,39 @@
 //! SSZ-encoded representations of Ethereum block structures.
 //!
-//! This module provides SSZ (Simple Serialize) compatible structures for Ethereum blocks.
-//!
-//! Note: SSZ is not currently used in the execution layer. For this reason, it doesn't yet have native support in
-//! Reth, so we define our own SSZ-compatible structures here. Whenever Reth adds native SSZ support,
-//! we can consider removing this module and using the native types directly.
+//! This module provides SSZ-compatible structures for Ethereum blocks using
+//! `libssz`'s native types and derives.
 
 use alloc::vec::Vec;
 
 use alloy_eips::eip4895;
-use alloy_primitives::{Address, B64, B256, BlockNumber, Bloom, Bytes, U256};
+use alloy_primitives::{BlockNumber, TxKind};
+use libssz::{SszDecode, SszEncode};
+use libssz_derive::{SszDecode, SszEncode};
+
+type Address20 = [u8; 20];
+type Hash32 = [u8; 32];
+type Uint256Bytes = [u8; 32];
+type NonceBytes = [u8; 8];
+type LogsBloom = [u8; 256];
+
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
+#[ssz(enum_behaviour = "union")]
+pub(crate) enum Maybe<T: SszEncode + SszDecode> {
+    None,
+    Some(T),
+}
+
+impl<T: SszEncode + SszDecode> From<Option<T>> for Maybe<T> {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(value) => Self::Some(value),
+            None => Self::None,
+        }
+    }
+}
 
 /// SSZ-serializable representation of an Ethereum block.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct Block {
     header: Header,
     body: BlockBody,
@@ -40,11 +61,11 @@ impl
 }
 
 /// SSZ-serializable representation of a block body.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct BlockBody {
     transactions: Vec<EthereumTxEnvelope>,
     ommers: Vec<Header>,
-    withdrawals: Option<Vec<Withdrawal>>,
+    withdrawals: Maybe<Vec<Withdrawal>>,
 }
 
 impl
@@ -66,71 +87,72 @@ impl
             ommers: body.ommers.into_iter().map(Header::from).collect(),
             withdrawals: body
                 .withdrawals
-                .map(|ws| ws.into_iter().map(Withdrawal::from).collect()),
+                .map(|ws| ws.into_iter().map(Withdrawal::from).collect())
+                .into(),
         }
     }
 }
 
 /// SSZ-serializable representation of an Ethereum block header.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct Header {
-    parent_hash: B256,
-    ommers_hash: B256,
-    beneficiary: Address,
-    state_root: B256,
-    transactions_root: B256,
-    receipts_root: B256,
-    logs_bloom: Bloom,
-    difficulty: U256,
+    parent_hash: Hash32,
+    ommers_hash: Hash32,
+    beneficiary: Address20,
+    state_root: Hash32,
+    transactions_root: Hash32,
+    receipts_root: Hash32,
+    logs_bloom: LogsBloom,
+    difficulty: Uint256Bytes,
     number: BlockNumber,
     gas_limit: u64,
     gas_used: u64,
     timestamp: u64,
-    extra_data: Bytes,
-    mix_hash: B256,
-    nonce: B64,
-    base_fee_per_gas: Option<u64>,
-    withdrawals_root: Option<B256>,
-    blob_gas_used: Option<u64>,
-    excess_blob_gas: Option<u64>,
-    parent_beacon_block_root: Option<B256>,
-    requests_hash: Option<B256>,
+    extra_data: Vec<u8>,
+    mix_hash: Hash32,
+    nonce: NonceBytes,
+    base_fee_per_gas: Maybe<u64>,
+    withdrawals_root: Maybe<Hash32>,
+    blob_gas_used: Maybe<u64>,
+    excess_blob_gas: Maybe<u64>,
+    parent_beacon_block_root: Maybe<Hash32>,
+    requests_hash: Maybe<Hash32>,
 }
 
 impl From<alloy_consensus::Header> for Header {
     fn from(header: alloy_consensus::Header) -> Self {
         Self {
-            parent_hash: header.parent_hash,
-            ommers_hash: header.ommers_hash,
-            beneficiary: header.beneficiary,
-            state_root: header.state_root,
-            transactions_root: header.transactions_root,
-            receipts_root: header.receipts_root,
-            logs_bloom: header.logs_bloom,
-            difficulty: header.difficulty,
+            parent_hash: header.parent_hash.into(),
+            ommers_hash: header.ommers_hash.into(),
+            beneficiary: header.beneficiary.into(),
+            state_root: header.state_root.into(),
+            transactions_root: header.transactions_root.into(),
+            receipts_root: header.receipts_root.into(),
+            logs_bloom: *header.logs_bloom.data(),
+            difficulty: header.difficulty.to_le_bytes(),
             number: header.number,
             gas_limit: header.gas_limit,
             gas_used: header.gas_used,
             timestamp: header.timestamp,
-            extra_data: header.extra_data,
-            mix_hash: header.mix_hash,
-            nonce: header.nonce,
-            base_fee_per_gas: header.base_fee_per_gas,
-            withdrawals_root: header.withdrawals_root,
-            blob_gas_used: header.blob_gas_used,
-            excess_blob_gas: header.excess_blob_gas,
-            parent_beacon_block_root: header.parent_beacon_block_root,
-            requests_hash: header.requests_hash,
+            extra_data: header.extra_data.to_vec(),
+            mix_hash: header.mix_hash.into(),
+            nonce: header.nonce.into(),
+            base_fee_per_gas: header.base_fee_per_gas.into(),
+            withdrawals_root: header.withdrawals_root.map(Into::into).into(),
+            blob_gas_used: header.blob_gas_used.into(),
+            excess_blob_gas: header.excess_blob_gas.into(),
+            parent_beacon_block_root: header.parent_beacon_block_root.map(Into::into).into(),
+            requests_hash: header.requests_hash.map(Into::into).into(),
         }
     }
 }
 
 /// SSZ-serializable representation of a validator withdrawal.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct Withdrawal {
     index: u64,
     validator_index: u64,
-    address: Address,
+    address: Address20,
     amount: u64,
 }
 
@@ -139,25 +161,20 @@ impl From<eip4895::Withdrawal> for Withdrawal {
         Self {
             index: withdrawal.index,
             validator_index: withdrawal.validator_index,
-            address: withdrawal.address,
+            address: withdrawal.address.into(),
             amount: withdrawal.amount,
         }
     }
 }
 
 /// SSZ-serializable transaction envelope supporting a subset of Ethereum transaction types.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 #[ssz(enum_behaviour = "union")]
 pub(crate) enum EthereumTxEnvelope {
-    /// Legacy transaction type.
     Legacy(SignedTx<TxLegacy>),
-    /// EIP-1559 transaction type.
     Eip1559(SignedTx<TxEip1559>),
-    /// EIP-4844 transaction type.
     Eip4844(SignedTx<TxEip4844>),
-    /// EIP-2930 transaction type.
     Eip2930(SignedTx<TxEip2930>),
-    /// EIP-7702 transaction type.
     Eip7702(SignedTx<TxEip7702>),
 }
 
@@ -173,9 +190,9 @@ impl From<alloy_consensus::EthereumTxEnvelope<alloy_consensus::TxEip4844>> for E
     }
 }
 
-/// SSZ-serializable representation of a signed legacy Ethereum transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
-pub(crate) struct SignedTx<Tx: ssz::Encode + ssz::Decode> {
+/// SSZ-serializable representation of a signed Ethereum transaction.
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
+pub(crate) struct SignedTx<Tx: SszEncode + SszDecode> {
     tx: Tx,
     signature: Signature,
 }
@@ -226,64 +243,61 @@ impl From<alloy_consensus::Signed<alloy_consensus::TxEip7702>> for SignedTx<TxEi
 }
 
 /// SSZ-serializable representation of an ECDSA signature.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct Signature {
     y_parity: bool,
-    r: U256,
-    s: U256,
+    r: Uint256Bytes,
+    s: Uint256Bytes,
 }
 
 impl From<alloy_primitives::Signature> for Signature {
     fn from(signature: alloy_primitives::Signature) -> Self {
         Self {
             y_parity: signature.v(),
-            r: signature.r(),
-            s: signature.s(),
+            r: signature.r().to_le_bytes(),
+            s: signature.s().to_le_bytes(),
         }
     }
 }
 
 /// SSZ-serializable representation of a legacy Ethereum transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct TxLegacy {
-    chain_id: Option<ChainId>,
+    chain_id: Maybe<ChainId>,
     nonce: u64,
     gas_price: u128,
     gas_limit: u64,
-    to: Address,
-    value: U256,
-    input: Bytes,
+    to: Address20,
+    value: Uint256Bytes,
+    input: Vec<u8>,
 }
 
 impl From<alloy_consensus::TxLegacy> for TxLegacy {
     fn from(tx: alloy_consensus::TxLegacy) -> Self {
         Self {
-            chain_id: tx.chain_id,
+            chain_id: tx.chain_id.into(),
             nonce: tx.nonce,
             gas_price: tx.gas_price,
             gas_limit: tx.gas_limit,
-            to: match tx.to {
-                alloy_primitives::TxKind::Create => Address::default(),
-                alloy_primitives::TxKind::Call(addr) => addr,
-            },
-            value: tx.value,
-            input: tx.input,
+            to: tx_kind_to_address(tx.to),
+            value: tx.value.to_le_bytes(),
+            input: tx.input.to_vec(),
         }
     }
 }
 
 /// SSZ-serializable representation of an EIP-1559 transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct TxEip1559 {
     chain_id: ChainId,
     nonce: u64,
     gas_limit: u64,
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
-    to: Address,
-    value: U256,
+    to: Address20,
+    value: Uint256Bytes,
     access_list: Vec<AccessListItem>,
-    input: Bytes,
+    input: Vec<u8>,
 }
 
 impl From<alloy_consensus::transaction::TxEip1559> for TxEip1559 {
@@ -294,45 +308,48 @@ impl From<alloy_consensus::transaction::TxEip1559> for TxEip1559 {
             gas_limit: value.gas_limit,
             max_fee_per_gas: value.max_fee_per_gas,
             max_priority_fee_per_gas: value.max_priority_fee_per_gas,
-            to: match value.to {
-                alloy_primitives::TxKind::Create => Address::default(),
-                alloy_primitives::TxKind::Call(addr) => addr,
-            },
-            value: value.value,
+            to: tx_kind_to_address(value.to),
+            value: value.value.to_le_bytes(),
             access_list: value
                 .access_list
                 .iter()
-                .map(|al| AccessListItem {
-                    address: al.address,
-                    storage_keys: al.storage_keys.clone(),
-                })
+                .map(AccessListItem::from)
                 .collect(),
-            input: value.input,
+            input: value.input.to_vec(),
         }
     }
 }
 
-/// SSZ-serializable representation of an access list.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+/// SSZ-serializable representation of an access list item.
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct AccessListItem {
-    address: Address,
-    storage_keys: Vec<B256>,
+    address: Address20,
+    storage_keys: Vec<Hash32>,
+}
+
+impl From<&alloy_eips::eip2930::AccessListItem> for AccessListItem {
+    fn from(value: &alloy_eips::eip2930::AccessListItem) -> Self {
+        Self {
+            address: value.address.into(),
+            storage_keys: value.storage_keys.iter().copied().map(Into::into).collect(),
+        }
+    }
 }
 
 /// SSZ-serializable representation of an EIP-4844 transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct TxEip4844 {
     chain_id: ChainId,
     nonce: u64,
     gas_limit: u64,
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
-    to: Address,
-    value: U256,
+    to: Address20,
+    value: Uint256Bytes,
     access_list: Vec<AccessListItem>,
-    blob_versioned_hashes: Vec<B256>,
+    blob_versioned_hashes: Vec<Hash32>,
     max_fee_per_blob_gas: u128,
-    input: Bytes,
+    input: Vec<u8>,
 }
 
 impl From<alloy_consensus::transaction::TxEip4844> for TxEip4844 {
@@ -343,34 +360,35 @@ impl From<alloy_consensus::transaction::TxEip4844> for TxEip4844 {
             gas_limit: value.gas_limit,
             max_fee_per_gas: value.max_fee_per_gas,
             max_priority_fee_per_gas: value.max_priority_fee_per_gas,
-            to: value.to,
-            value: value.value,
+            to: value.to.into(),
+            value: value.value.to_le_bytes(),
             access_list: value
                 .access_list
                 .iter()
-                .map(|al| AccessListItem {
-                    address: al.address,
-                    storage_keys: al.storage_keys.clone(),
-                })
+                .map(AccessListItem::from)
                 .collect(),
-            blob_versioned_hashes: value.blob_versioned_hashes,
+            blob_versioned_hashes: value
+                .blob_versioned_hashes
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             max_fee_per_blob_gas: value.max_fee_per_blob_gas,
-            input: value.input,
+            input: value.input.to_vec(),
         }
     }
 }
 
 /// SSZ-serializable representation of an EIP-2930 transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct TxEip2930 {
     chain_id: ChainId,
     nonce: u64,
     gas_price: u128,
     gas_limit: u64,
-    to: Address,
-    value: U256,
+    to: Address20,
+    value: Uint256Bytes,
     access_list: Vec<AccessListItem>,
-    input: Bytes,
+    input: Vec<u8>,
 }
 
 impl From<alloy_consensus::transaction::TxEip2930> for TxEip2930 {
@@ -380,37 +398,31 @@ impl From<alloy_consensus::transaction::TxEip2930> for TxEip2930 {
             nonce: value.nonce,
             gas_price: value.gas_price,
             gas_limit: value.gas_limit,
-            to: match value.to {
-                alloy_primitives::TxKind::Create => Address::default(),
-                alloy_primitives::TxKind::Call(addr) => addr,
-            },
-            value: value.value,
+            to: tx_kind_to_address(value.to),
+            value: value.value.to_le_bytes(),
             access_list: value
                 .access_list
                 .iter()
-                .map(|al| AccessListItem {
-                    address: al.address,
-                    storage_keys: al.storage_keys.clone(),
-                })
+                .map(AccessListItem::from)
                 .collect(),
-            input: value.input,
+            input: value.input.to_vec(),
         }
     }
 }
 
 /// SSZ-serializable representation of an EIP-7702 transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct TxEip7702 {
     chain_id: ChainId,
     nonce: u64,
     gas_limit: u64,
     max_fee_per_gas: u128,
     max_priority_fee_per_gas: u128,
-    to: Address,
-    value: U256,
+    to: Address20,
+    value: Uint256Bytes,
     access_list: Vec<AccessListItem>,
     authorization_list: Vec<SignedAuthorization>,
-    input: Bytes,
+    input: Vec<u8>,
 }
 
 impl From<alloy_consensus::transaction::TxEip7702> for TxEip7702 {
@@ -421,33 +433,30 @@ impl From<alloy_consensus::transaction::TxEip7702> for TxEip7702 {
             gas_limit: value.gas_limit,
             max_fee_per_gas: value.max_fee_per_gas,
             max_priority_fee_per_gas: value.max_priority_fee_per_gas,
-            to: value.to,
-            value: value.value,
+            to: value.to.into(),
+            value: value.value.to_le_bytes(),
             access_list: value
                 .access_list
                 .iter()
-                .map(|al| AccessListItem {
-                    address: al.address,
-                    storage_keys: al.storage_keys.clone(),
-                })
+                .map(AccessListItem::from)
                 .collect(),
             authorization_list: value
                 .authorization_list
                 .into_iter()
                 .map(SignedAuthorization::from)
                 .collect(),
-            input: value.input,
+            input: value.input.to_vec(),
         }
     }
 }
 
 /// SSZ-serializable representation of an authorization for an EIP-7702 transaction.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct SignedAuthorization {
     inner: Authorization,
     y_parity: bool,
-    r: U256,
-    s: U256,
+    r: Uint256Bytes,
+    s: Uint256Bytes,
 }
 
 impl From<alloy_eips::eip7702::SignedAuthorization> for SignedAuthorization {
@@ -455,25 +464,25 @@ impl From<alloy_eips::eip7702::SignedAuthorization> for SignedAuthorization {
         Self {
             inner: auth.inner().clone().into(),
             y_parity: auth.signature().unwrap().v(),
-            r: auth.signature().unwrap().r(),
-            s: auth.signature().unwrap().s(),
+            r: auth.signature().unwrap().r().to_le_bytes(),
+            s: auth.signature().unwrap().s().to_le_bytes(),
         }
     }
 }
 
 /// SSZ-serializable representation of an authorization.
-#[derive(Debug, PartialEq, Eq, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, PartialEq, Eq, SszEncode, SszDecode)]
 pub(crate) struct Authorization {
-    chain_id: U256,
-    address: Address,
+    chain_id: Uint256Bytes,
+    address: Address20,
     nonce: u64,
 }
 
 impl From<alloy_eips::eip7702::Authorization> for Authorization {
     fn from(auth: alloy_eips::eip7702::Authorization) -> Self {
         Self {
-            chain_id: auth.chain_id,
-            address: auth.address,
+            chain_id: auth.chain_id.to_le_bytes(),
+            address: auth.address.into(),
             nonce: auth.nonce,
         }
     }
@@ -482,15 +491,21 @@ impl From<alloy_eips::eip7702::Authorization> for Authorization {
 /// Type alias for Ethereum chain identifiers.
 pub(crate) type ChainId = u64;
 
+fn tx_kind_to_address(kind: TxKind) -> Address20 {
+    match kind {
+        TxKind::Create => [0u8; 20],
+        TxKind::Call(address) => address.into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use ssz::{Decode, Encode};
+    use libssz::{SszDecode, SszEncode};
 
     use crate::guest::{BincodeBlock, block_ssz::Block};
 
     #[test]
     fn test_block_ssz_encode_decode() {
-        // Sample block data in JSON format for testing
         let block_json = r#"
         {
             "header": {
@@ -543,25 +558,81 @@ mod tests {
             }
         }"#;
 
-        // Parse the JSON into our bincode-compatible format
         let bincode_block: BincodeBlock =
             serde_json::from_str(block_json).expect("Failed to parse test block JSON");
-
-        // Convert to our SSZ-compatible block format
         let ssz_block: Block = bincode_block.0.into();
 
-        // Encode the block using SSZ
-        let ssz_bytes = ssz_block.as_ssz_bytes();
+        let ssz_bytes = ssz_block.to_ssz();
         assert!(!ssz_bytes.is_empty(), "SSZ encoding should not be empty");
 
-        // Decode the block back from SSZ bytes
         let decoded_block: Block =
             Block::from_ssz_bytes(&ssz_bytes).expect("Failed to decode SSZ bytes back to Block");
 
-        // Verify that round-trip encoding/decoding preserves the data
         assert_eq!(
             ssz_block, decoded_block,
             "Round-trip encoding should preserve block data"
+        );
+    }
+
+    #[test]
+    fn test_block_ssz_encode_decode_without_optional_fields() {
+        let block_json = r#"
+        {
+            "header": {
+                "parent_hash": "0x5448165948733a50620ce604351e52218152fce74695792bb63042af34731072",
+                "ommers_hash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                "beneficiary": "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+                "state_root": "0x275620cf6a1271bf8cae4edadda0076897f09cd2bef8533ea7e7e13ba8d8e225",
+                "transactions_root": "0x7c610e7810983ef78836bef4c3beb6aec3131a7589898d46904d302c76ea4836",
+                "receipts_root": "0x6ebeb82e2fd4ad8ef581ba011ed8590752fbb658e86bb4f29d186cba3f7b1357",
+                "logs_bloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+                "difficulty": "0x0",
+                "number": 1,
+                "gas_limit": 100000000000,
+                "gas_used": 21000,
+                "timestamp": 12,
+                "mix_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "nonce": "0x0000000000000000",
+                "extra_data": "0x"
+            },
+            "body": {
+                "transactions": [
+                {
+                    "signature": {
+                    "r": "0x8f29ffe2060a6e48c5fd6c1e225d53638b64602fd1ffdab6896f867d4a58d5e0",
+                    "s": "0x1901323b25372c41b46c46e1c63f4bb246a3e22b9c61536c45ed19008cbbd0b8",
+                    "yParity": "0x0",
+                    "v": "0x0"
+                    },
+                    "transaction": {
+                    "Legacy": {
+                        "nonce": 0,
+                        "gas_price": 10,
+                        "gas_limit": 21000,
+                        "to": "0x0000000000000000000000000000000000001100",
+                        "value": "0x0",
+                        "input": "0x"
+                    }
+                    }
+                }
+                ],
+                "ommers": []
+            }
+        }"#;
+
+        let bincode_block: BincodeBlock =
+            serde_json::from_str(block_json).expect("Failed to parse test block JSON");
+        let ssz_block: Block = bincode_block.0.into();
+
+        let ssz_bytes = ssz_block.to_ssz();
+        assert!(!ssz_bytes.is_empty(), "SSZ encoding should not be empty");
+
+        let decoded_block: Block =
+            Block::from_ssz_bytes(&ssz_bytes).expect("Failed to decode SSZ bytes back to Block");
+
+        assert_eq!(
+            ssz_block, decoded_block,
+            "Round-trip encoding should preserve optional fields"
         );
     }
 }

--- a/crates/stateless-validator-common/Cargo.toml
+++ b/crates/stateless-validator-common/Cargo.toml
@@ -17,15 +17,11 @@ serde = { workspace = true, optional = true, features = [
     "alloc",
 ], default-features = false }
 
-# lighthouse
-tree_hash.workspace = true
-tree_hash_derive.workspace = true
-ssz_types.workspace = true
-typenum.workspace = true
-
 # ssz
-ethereum_ssz.workspace = true
-ethereum_ssz_derive.workspace = true
+libssz.workspace = true
+libssz_derive.workspace = true
+libssz_merkle.workspace = true
+libssz_types.workspace = true
 
 #alloy
 alloy-primitives = { workspace = true, optional = true }

--- a/crates/stateless-validator-common/src/host.rs
+++ b/crates/stateless-validator-common/src/host.rs
@@ -1,9 +1,9 @@
 //! Stateless validator common types and utilities for host.
 
 use anyhow::{Context, Result};
+use libssz::{SszDecode, SszEncode};
+use libssz_types::SszList;
 use sha2::{Digest, Sha256};
-use ssz::{Decode, Encode};
-use ssz_types::VariableList;
 
 use crate::{
     guest::StatelessValidatorOutput,
@@ -39,9 +39,7 @@ impl NewPayloadRequest {
         versioned_hashes: Vec<Hash32>,
         parent_beacon_block_root: Hash32,
     ) -> Result<Self> {
-        let versioned_hashes = VariableList::new(versioned_hashes).map_err(|err| {
-            anyhow::anyhow!("Versioned hashes length should be within bounds: {:?}", err)
-        })?;
+        let versioned_hashes = bounded_list(versioned_hashes, "versioned hashes")?;
         Ok(NewPayloadRequest::Deneb(NewPayloadRequestDeneb {
             execution_payload,
             versioned_hashes,
@@ -56,9 +54,7 @@ impl NewPayloadRequest {
         parent_beacon_block_root: Hash32,
         execution_requests: &[impl AsRef<[u8]>],
     ) -> Result<Self> {
-        let versioned_hashes = VariableList::new(versioned_hashes).map_err(|err| {
-            anyhow::anyhow!("Versioned hashes length should be within bounds: {:?}", err)
-        })?;
+        let versioned_hashes = bounded_list(versioned_hashes, "versioned hashes")?;
         let execution_requests = decode_execution_requests(execution_requests)
             .context("Decoding execution requests failed")?;
         Ok(NewPayloadRequest::ElectraFulu(
@@ -70,6 +66,11 @@ impl NewPayloadRequest {
             },
         ))
     }
+}
+
+fn bounded_list<T, const N: usize>(values: Vec<T>, label: &str) -> Result<SszList<T, N>> {
+    SszList::try_from(values)
+        .map_err(|err| anyhow::anyhow!("{label} length should be within bounds: {err:?}"))
 }
 
 /// Decodes a list of execution requests obtained from execution and deserializes them into an
@@ -86,9 +87,9 @@ fn decode_execution_requests(requests_list: &[impl AsRef<[u8]>]) -> Result<Execu
     const CONSOLIDATION_REQUEST_TYPE: u8 = 0x02;
 
     // Fixed SSZ sizes for each request type (excluding the type byte)
-    let deposit_request_size = <DepositRequest as Encode>::ssz_fixed_len();
-    let withdrawal_request_size = <WithdrawalRequest as Encode>::ssz_fixed_len();
-    let consolidation_request_size = <ConsolidationRequest as Encode>::ssz_fixed_len();
+    let deposit_request_size = <DepositRequest as SszEncode>::fixed_size();
+    let withdrawal_request_size = <WithdrawalRequest as SszEncode>::fixed_size();
+    let consolidation_request_size = <ConsolidationRequest as SszEncode>::fixed_size();
 
     let mut deposits = Vec::new();
     let mut withdrawals = Vec::new();
@@ -189,12 +190,8 @@ fn decode_execution_requests(requests_list: &[impl AsRef<[u8]>]) -> Result<Execu
     }
 
     Ok(ExecutionRequests {
-        deposits: VariableList::new(deposits)
-            .map_err(|e| anyhow::anyhow!("Failed to create deposits VariableList: {:?}", e))?,
-        withdrawals: VariableList::new(withdrawals)
-            .map_err(|e| anyhow::anyhow!("Failed to create withdrawals VariableList: {:?}", e))?,
-        consolidations: VariableList::new(consolidations).map_err(|e| {
-            anyhow::anyhow!("Failed to create consolidations VariableList: {:?}", e)
-        })?,
+        deposits: bounded_list(deposits, "deposits")?,
+        withdrawals: bounded_list(withdrawals, "withdrawals")?,
+        consolidations: bounded_list(consolidations, "consolidations")?,
     })
 }

--- a/crates/stateless-validator-common/src/new_payload_request.rs
+++ b/crates/stateless-validator-common/src/new_payload_request.rs
@@ -102,13 +102,13 @@ pub struct ConsolidationRequest {
 )]
 pub struct ExecutionRequests {
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub deposits: DepositRequests,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub withdrawals: WithdrawalRequests,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub consolidations: ConsolidationRequests,
 }
 
@@ -140,7 +140,7 @@ pub struct ExecutionPayloadV1 {
     pub gas_used: u64,
     pub timestamp: u64,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
@@ -148,7 +148,7 @@ pub struct ExecutionPayloadV1 {
         feature = "serde",
         serde(with = "crate::serde_wrappers::nested_ssz_list")
     )]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedSszList))]
     pub transactions: Transactions,
 }
 
@@ -171,7 +171,7 @@ pub struct ExecutionPayloadV2 {
     pub gas_used: u64,
     pub timestamp: u64,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
@@ -179,10 +179,10 @@ pub struct ExecutionPayloadV2 {
         feature = "serde",
         serde(with = "crate::serde_wrappers::nested_ssz_list")
     )]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedSszList))]
     pub transactions: Transactions,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub withdrawals: Withdrawals,
 }
 
@@ -205,7 +205,7 @@ pub struct ExecutionPayloadV3 {
     pub gas_used: u64,
     pub timestamp: u64,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
@@ -213,10 +213,10 @@ pub struct ExecutionPayloadV3 {
         feature = "serde",
         serde(with = "crate::serde_wrappers::nested_ssz_list")
     )]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedSszList))]
     pub transactions: Transactions,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub withdrawals: Withdrawals,
     pub blob_gas_used: u64,
     pub excess_blob_gas: u64,
@@ -251,7 +251,7 @@ pub struct NewPayloadRequestCapella {
 pub struct NewPayloadRequestDeneb {
     pub execution_payload: ExecutionPayloadV3,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub versioned_hashes: VersionedHashes,
     pub parent_beacon_block_root: Hash32,
 }
@@ -265,7 +265,7 @@ pub struct NewPayloadRequestDeneb {
 pub struct NewPayloadRequestElectraFulu {
     pub execution_payload: ExecutionPayloadV3,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
+    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsSszList))]
     pub versioned_hashes: VersionedHashes,
     pub parent_beacon_block_root: Hash32,
     pub execution_requests: ExecutionRequests,

--- a/crates/stateless-validator-common/src/new_payload_request.rs
+++ b/crates/stateless-validator-common/src/new_payload_request.rs
@@ -2,14 +2,13 @@
 
 #![allow(missing_docs)]
 
-use alloc::vec::Vec;
+use alloc::{vec, vec::Vec};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use ssz_types::{FixedVector, VariableList};
-use tree_hash::TreeHash;
-use tree_hash_derive::TreeHash;
-use typenum::Prod;
+use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
+use libssz_merkle::HashTreeRoot;
+use libssz_types::SszList;
 
 /// Primitive types
 pub type Hash32 = [u8; 32];
@@ -17,24 +16,29 @@ pub type Bytes48 = [u8; 48];
 pub type Bytes96 = [u8; 96];
 pub type Address20 = [u8; 20];
 pub type Uint256Bytes = [u8; 32];
-pub type LogsBloom = FixedVector<u8, typenum::U256>;
-pub type ExtraData = VariableList<u8, typenum::U32>;
+pub type LogsBloom = [u8; 256];
+pub type ExtraData = SszList<u8, 32>;
 
 /// Limits
-pub type MaxBytesPerTransaction = Prod<MaxTransactionsPerPayload, typenum::U1024>; // 2^30
-pub type MaxWithdrawalsPerPayload = typenum::U16; // 16
-pub type MaxTransactionsPerPayload = Prod<typenum::U1024, typenum::U1024>; // 2^20
-pub type MaxBlobCommitmentsPerBlock = typenum::U4096; // 4096
-pub type MaxDepositRequestsPerPayload = typenum::U8192; // 2^13
-pub type MaxWithdrawalRequestsPerPayload = typenum::U16; // 2^4
-pub type MaxConsolidationRequestsPerPayload = typenum::U2; // 2^1
+pub const MAX_WITHDRAWALS_PER_PAYLOAD: usize = 16;
+pub const MAX_TRANSACTIONS_PER_PAYLOAD: usize = 1024 * 1024;
+pub const MAX_BYTES_PER_TRANSACTION: usize = MAX_TRANSACTIONS_PER_PAYLOAD * 1024;
+pub const MAX_BLOB_COMMITMENTS_PER_BLOCK: usize = 4096;
+pub const MAX_DEPOSIT_REQUESTS_PER_PAYLOAD: usize = 8192;
+pub const MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: usize = 16;
+pub const MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: usize = 2;
 
 /// Composite types
-pub type Transaction = VariableList<u8, MaxBytesPerTransaction>;
-pub type Transactions = VariableList<Transaction, MaxTransactionsPerPayload>;
-pub type Withdrawals = VariableList<Withdrawal, MaxWithdrawalsPerPayload>;
+pub type Transaction = SszList<u8, MAX_BYTES_PER_TRANSACTION>;
+pub type Transactions = SszList<Transaction, MAX_TRANSACTIONS_PER_PAYLOAD>;
+pub type Withdrawals = SszList<Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD>;
+pub type VersionedHashes = SszList<Hash32, MAX_BLOB_COMMITMENTS_PER_BLOCK>;
+pub type DepositRequests = SszList<DepositRequest, MAX_DEPOSIT_REQUESTS_PER_PAYLOAD>;
+pub type WithdrawalRequests = SszList<WithdrawalRequest, MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD>;
+pub type ConsolidationRequests =
+    SszList<ConsolidationRequest, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD>;
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot, SszEncode, SszDecode)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -48,7 +52,7 @@ pub struct Withdrawal {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, TreeHash, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, Clone, HashTreeRoot, SszEncode, SszDecode)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -64,7 +68,7 @@ pub struct DepositRequest {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, TreeHash, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, Clone, HashTreeRoot, SszEncode, SszDecode)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -77,7 +81,7 @@ pub struct WithdrawalRequest {
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, TreeHash, ssz_derive::Encode, ssz_derive::Decode)]
+#[derive(Debug, Clone, HashTreeRoot, SszEncode, SszDecode)]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -90,19 +94,22 @@ pub struct ConsolidationRequest {
     pub target_pubkey: Bytes48,
 }
 
-#[derive(Debug, Clone, Default, TreeHash)]
+#[derive(Debug, Clone, Default, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
 pub struct ExecutionRequests {
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
-    pub deposits: VariableList<DepositRequest, MaxDepositRequestsPerPayload>,
+    pub deposits: DepositRequests,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
-    pub withdrawals: VariableList<WithdrawalRequest, MaxWithdrawalRequestsPerPayload>,
+    pub withdrawals: WithdrawalRequests,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
-    pub consolidations: VariableList<ConsolidationRequest, MaxConsolidationRequestsPerPayload>,
+    pub consolidations: ConsolidationRequests,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -114,7 +121,7 @@ pub enum ForkName {
     Fulu,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -125,22 +132,24 @@ pub struct ExecutionPayloadV1 {
     pub fee_recipient: Address20,
     pub state_root: Hash32,
     pub receipts_root: Hash32,
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsFixedVector))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::bytes_array"))]
     pub logs_bloom: LogsBloom,
     pub prev_randao: Hash32,
     pub block_number: u64,
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::nested_ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
     pub transactions: Transactions,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -151,24 +160,27 @@ pub struct ExecutionPayloadV2 {
     pub fee_recipient: Address20,
     pub state_root: Hash32,
     pub receipts_root: Hash32,
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsFixedVector))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::bytes_array"))]
     pub logs_bloom: LogsBloom,
     pub prev_randao: Hash32,
     pub block_number: u64,
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::nested_ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
     pub transactions: Transactions,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
     pub withdrawals: Withdrawals,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -179,26 +191,29 @@ pub struct ExecutionPayloadV3 {
     pub fee_recipient: Address20,
     pub state_root: Hash32,
     pub receipts_root: Hash32,
-    #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsFixedVector))]
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::bytes_array"))]
     pub logs_bloom: LogsBloom,
     pub prev_randao: Hash32,
     pub block_number: u64,
     pub gas_limit: u64,
     pub gas_used: u64,
     pub timestamp: u64,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::nested_ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
     pub transactions: Transactions,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
     pub withdrawals: Withdrawals,
     pub blob_gas_used: u64,
     pub excess_blob_gas: u64,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -208,7 +223,7 @@ pub struct NewPayloadRequestBellatrix {
     pub execution_payload: ExecutionPayloadV1,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -218,7 +233,7 @@ pub struct NewPayloadRequestCapella {
     pub execution_payload: ExecutionPayloadV2,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -226,12 +241,13 @@ pub struct NewPayloadRequestCapella {
 )]
 pub struct NewPayloadRequestDeneb {
     pub execution_payload: ExecutionPayloadV3,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
-    pub versioned_hashes: VariableList<Hash32, MaxBlobCommitmentsPerBlock>,
+    pub versioned_hashes: VersionedHashes,
     pub parent_beacon_block_root: Hash32,
 }
 
-#[derive(Debug, Clone, TreeHash)]
+#[derive(Debug, Clone, HashTreeRoot)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(
     feature = "rkyv",
@@ -239,8 +255,9 @@ pub struct NewPayloadRequestDeneb {
 )]
 pub struct NewPayloadRequestElectraFulu {
     pub execution_payload: ExecutionPayloadV3,
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsVariableList))]
-    pub versioned_hashes: VariableList<Hash32, MaxBlobCommitmentsPerBlock>,
+    pub versioned_hashes: VersionedHashes,
     pub parent_beacon_block_root: Hash32,
     pub execution_requests: ExecutionRequests,
 }
@@ -261,25 +278,25 @@ pub enum NewPayloadRequest {
 impl NewPayloadRequest {
     pub fn tree_hash_root(&self) -> [u8; 32] {
         match self {
-            NewPayloadRequest::Bellatrix(req) => req.tree_hash_root().0,
-            NewPayloadRequest::Capella(req) => req.tree_hash_root().0,
-            NewPayloadRequest::Deneb(req) => req.tree_hash_root().0,
-            NewPayloadRequest::ElectraFulu(req) => req.tree_hash_root().0,
+            NewPayloadRequest::Bellatrix(req) => req.hash_tree_root(),
+            NewPayloadRequest::Capella(req) => req.hash_tree_root(),
+            NewPayloadRequest::Deneb(req) => req.hash_tree_root(),
+            NewPayloadRequest::ElectraFulu(req) => req.hash_tree_root(),
         }
     }
 }
 
 /// Computes the requests hash for EL block construction.
 pub fn compute_requests_hash(requests: &ExecutionRequests) -> [u8; 32] {
+    use libssz::SszEncode;
     use sha2::{Digest, Sha256};
-    use ssz::Encode;
 
     let mut outer_hasher = Sha256::new();
 
     // Deposit requests (type 0x00)
     let mut deposits_bytes = vec![0x00u8];
     for deposit in requests.deposits.iter() {
-        deposits_bytes.extend(deposit.as_ssz_bytes());
+        deposits_bytes.extend(deposit.to_ssz());
     }
     if deposits_bytes.len() > 1 {
         outer_hasher.update(Sha256::digest(&deposits_bytes));
@@ -288,7 +305,7 @@ pub fn compute_requests_hash(requests: &ExecutionRequests) -> [u8; 32] {
     // Withdrawal requests (type 0x01)
     let mut withdrawals_bytes = vec![0x01u8];
     for withdrawal in requests.withdrawals.iter() {
-        withdrawals_bytes.extend(withdrawal.as_ssz_bytes());
+        withdrawals_bytes.extend(withdrawal.to_ssz());
     }
     if withdrawals_bytes.len() > 1 {
         outer_hasher.update(Sha256::digest(&withdrawals_bytes));
@@ -297,7 +314,7 @@ pub fn compute_requests_hash(requests: &ExecutionRequests) -> [u8; 32] {
     // Consolidation requests (type 0x02)
     let mut consolidations_bytes = vec![0x02u8];
     for consolidation in requests.consolidations.iter() {
-        consolidations_bytes.extend(consolidation.as_ssz_bytes());
+        consolidations_bytes.extend(consolidation.to_ssz());
     }
     if consolidations_bytes.len() > 1 {
         outer_hasher.update(Sha256::digest(&consolidations_bytes));

--- a/crates/stateless-validator-common/src/new_payload_request.rs
+++ b/crates/stateless-validator-common/src/new_payload_request.rs
@@ -4,11 +4,11 @@
 
 use alloc::{vec, vec::Vec};
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
 use libssz_merkle::HashTreeRoot;
 use libssz_types::SszList;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Primitive types
 pub type Hash32 = [u8; 32];
@@ -144,7 +144,10 @@ pub struct ExecutionPayloadV1 {
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::nested_ssz_list"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_wrappers::nested_ssz_list")
+    )]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
     pub transactions: Transactions,
 }
@@ -172,7 +175,10 @@ pub struct ExecutionPayloadV2 {
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::nested_ssz_list"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_wrappers::nested_ssz_list")
+    )]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
     pub transactions: Transactions,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]
@@ -203,7 +209,10 @@ pub struct ExecutionPayloadV3 {
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
-    #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::nested_ssz_list"))]
+    #[cfg_attr(
+        feature = "serde",
+        serde(with = "crate::serde_wrappers::nested_ssz_list")
+    )]
     #[cfg_attr(feature = "rkyv", rkyv(with = crate::rkyv_wrappers::AsNestedVariableList))]
     pub transactions: Transactions,
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_wrappers::ssz_list"))]

--- a/crates/stateless-validator-common/src/rkyv_wrappers.rs
+++ b/crates/stateless-validator-common/src/rkyv_wrappers.rs
@@ -1,6 +1,6 @@
-//! rkyv wrappers for ssz_types (VariableList, FixedVector).
+//! rkyv wrappers for `libssz_types`.
 //!
-//! ssz_types doesn't support rkyv natively, so we provide wrappers that
+//! `libssz_types` doesn't support rkyv natively, so we provide wrappers that
 //! serialize them as `Vec<T>` and reconstruct on deserialization.
 
 use alloc::{format, string::String, vec::Vec};
@@ -13,10 +13,9 @@ use rkyv::{
     vec::{ArchivedVec, VecResolver},
     with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
-use ssz_types::{FixedVector, VariableList};
-use typenum::Unsigned;
+use libssz_types::SszList;
 
-/// Simple error wrapper for ssz_types errors which don't implement std::error::Error.
+/// Simple error wrapper for `libssz_types` errors which don't implement `std::error::Error`.
 #[derive(Debug)]
 struct SszError(String);
 
@@ -28,141 +27,78 @@ impl fmt::Display for SszError {
 
 impl core::error::Error for SszError {}
 
-/// Wrapper to serialize `VariableList<T, N>` as `Vec<T>`.
+/// Wrapper to serialize `SszList<T, N>` as `Vec<T>`.
 ///
 /// On serialization, the inner slice is serialized as a Vec.
-/// On deserialization, the Vec is converted back to VariableList.
+/// On deserialization, the Vec is converted back to `SszList`.
 #[derive(Debug)]
 pub struct AsVariableList;
 
-impl<T, N> ArchiveWith<VariableList<T, N>> for AsVariableList
+impl<T, const N: usize> ArchiveWith<SszList<T, N>> for AsVariableList
 where
     T: Archive,
-    N: Unsigned,
 {
     type Archived = ArchivedVec<T::Archived>;
     type Resolver = VecResolver;
 
     fn resolve_with(
-        field: &VariableList<T, N>,
+        field: &SszList<T, N>,
         resolver: Self::Resolver,
         out: Place<Self::Archived>,
     ) {
-        // VariableList implements Deref<Target = [T]>
         ArchivedVec::resolve_from_slice(field.deref(), resolver, out);
     }
 }
 
-impl<T, N, S> SerializeWith<VariableList<T, N>, S> for AsVariableList
+impl<T, const N: usize, S> SerializeWith<SszList<T, N>, S> for AsVariableList
 where
     T: Serialize<S>,
-    N: Unsigned,
     S: Fallible + Allocator + Writer + ?Sized,
 {
     fn serialize_with(
-        field: &VariableList<T, N>,
+        field: &SszList<T, N>,
         serializer: &mut S,
     ) -> Result<Self::Resolver, S::Error> {
         ArchivedVec::serialize_from_slice(field.deref(), serializer)
     }
 }
 
-impl<T, N, D> DeserializeWith<ArchivedVec<T::Archived>, VariableList<T, N>, D> for AsVariableList
+impl<T, const N: usize, D> DeserializeWith<ArchivedVec<T::Archived>, SszList<T, N>, D>
+    for AsVariableList
 where
     T: Archive,
     T::Archived: Deserialize<T, D>,
-    N: Unsigned,
     D: Fallible + ?Sized,
     D::Error: Source,
 {
     fn deserialize_with(
         archived: &ArchivedVec<T::Archived>,
         deserializer: &mut D,
-    ) -> Result<VariableList<T, N>, D::Error> {
+    ) -> Result<SszList<T, N>, D::Error> {
         let vec: Vec<T> = Deserialize::<Vec<T>, D>::deserialize(archived, deserializer)?;
-        // VariableList::new returns Err if vec.len() > N::to_usize()
-        // This shouldn't happen if data was serialized correctly
-        VariableList::new(vec).map_err(|e| <D::Error as Source>::new(SszError(format!("{e:?}"))))
+        SszList::try_from(vec).map_err(|e| <D::Error as Source>::new(SszError(format!("{e:?}"))))
     }
 }
 
-/// Wrapper to serialize `FixedVector<T, N>` as `Vec<T>`.
+/// Wrapper for nested `SszList` types like `SszList<SszList<u8, M>, N>`.
 ///
-/// On serialization, the inner slice is serialized as a Vec.
-/// On deserialization, the Vec is converted back to FixedVector.
-#[derive(Debug)]
-pub struct AsFixedVector;
-
-impl<T, N> ArchiveWith<FixedVector<T, N>> for AsFixedVector
-where
-    T: Archive,
-    N: Unsigned,
-{
-    type Archived = ArchivedVec<T::Archived>;
-    type Resolver = VecResolver;
-
-    fn resolve_with(
-        field: &FixedVector<T, N>,
-        resolver: Self::Resolver,
-        out: Place<Self::Archived>,
-    ) {
-        // FixedVector implements Deref<Target = [T]>
-        ArchivedVec::resolve_from_slice(field.deref(), resolver, out);
-    }
-}
-
-impl<T, N, S> SerializeWith<FixedVector<T, N>, S> for AsFixedVector
-where
-    T: Serialize<S>,
-    N: Unsigned,
-    S: Fallible + Allocator + Writer + ?Sized,
-{
-    fn serialize_with(
-        field: &FixedVector<T, N>,
-        serializer: &mut S,
-    ) -> Result<Self::Resolver, S::Error> {
-        ArchivedVec::serialize_from_slice(field.deref(), serializer)
-    }
-}
-
-impl<T, N, D> DeserializeWith<ArchivedVec<T::Archived>, FixedVector<T, N>, D> for AsFixedVector
-where
-    T: Archive + Clone + Default,
-    T::Archived: Deserialize<T, D>,
-    N: Unsigned,
-    D: Fallible + ?Sized,
-    D::Error: Source,
-{
-    fn deserialize_with(
-        archived: &ArchivedVec<T::Archived>,
-        deserializer: &mut D,
-    ) -> Result<FixedVector<T, N>, D::Error> {
-        let vec: Vec<T> = Deserialize::<Vec<T>, D>::deserialize(archived, deserializer)?;
-        // FixedVector::new returns Err if vec.len() != N::to_usize()
-        FixedVector::new(vec).map_err(|e| <D::Error as Source>::new(SszError(format!("{e:?}"))))
-    }
-}
-
-/// Wrapper for nested VariableList types like `VariableList<VariableList<u8, M>, N>`.
-///
-/// This is used for fields like `Transactions = VariableList<Transaction, _>`
-/// where `Transaction = VariableList<u8, _>`.
+/// This is used for fields like `Transactions = SszList<Transaction, _>`
+/// where `Transaction = SszList<u8, _>`.
 ///
 /// Serializes as `Vec<Vec<T>>` and reconstructs on deserialization.
 #[derive(Debug)]
 pub struct AsNestedVariableList;
 
-impl<T, M, N> ArchiveWith<VariableList<VariableList<T, M>, N>> for AsNestedVariableList
+impl<T, const M: usize, const N: usize> ArchiveWith<SszList<SszList<T, M>, N>>
+    for AsNestedVariableList
 where
     T: Archive,
-    M: Unsigned,
-    N: Unsigned,
 {
     type Archived = ArchivedVec<ArchivedVec<T::Archived>>;
     type Resolver = VecResolver;
 
     fn resolve_with(
-        field: &VariableList<VariableList<T, M>, N>,
+        field: &SszList<SszList<T, M>, N>,
         resolver: Self::Resolver,
         out: Place<Self::Archived>,
     ) {
@@ -170,33 +106,25 @@ where
     }
 }
 
-impl<T, M, N, S> SerializeWith<VariableList<VariableList<T, M>, N>, S> for AsNestedVariableList
+impl<T, const M: usize, const N: usize, S> SerializeWith<SszList<SszList<T, M>, N>, S>
+    for AsNestedVariableList
 where
     T: Serialize<S>,
-    M: Unsigned,
-    N: Unsigned,
     S: Fallible + Allocator + Writer + ?Sized,
 {
     fn serialize_with(
-        field: &VariableList<VariableList<T, M>, N>,
+        field: &SszList<SszList<T, M>, N>,
         serializer: &mut S,
     ) -> Result<Self::Resolver, S::Error> {
-        // Convert to Vec<Vec<T>> and serialize that
         let vecs: Vec<&[T]> = field.iter().map(|inner| inner.deref()).collect();
-
-        // We need to serialize as Vec<Vec<T>> which archives to ArchivedVec<ArchivedVec<T::Archived>>
-        // But we have Vec<&[T]>, so we need to serialize each slice individually
         ArchivedVec::serialize_from_iter(
-            vecs.iter().map(|slice| {
-                // Each slice needs to be wrapped to serialize as ArchivedVec
-                SliceAsVec(slice)
-            }),
+            vecs.iter().map(|slice| SliceAsVec(slice)),
             serializer,
         )
     }
 }
 
-/// Helper wrapper to serialize a slice as ArchivedVec
+/// Helper wrapper to serialize a slice as `ArchivedVec`.
 struct SliceAsVec<'a, T>(&'a [T]);
 
 impl<T: Archive> Archive for SliceAsVec<'_, T> {
@@ -216,29 +144,27 @@ impl<T: Serialize<S>, S: Fallible + Allocator + Writer + ?Sized> Serialize<S>
     }
 }
 
-impl<T, M, N, D>
-    DeserializeWith<ArchivedVec<ArchivedVec<T::Archived>>, VariableList<VariableList<T, M>, N>, D>
+impl<T, const M: usize, const N: usize, D>
+    DeserializeWith<ArchivedVec<ArchivedVec<T::Archived>>, SszList<SszList<T, M>, N>, D>
     for AsNestedVariableList
 where
     T: Archive,
     T::Archived: Deserialize<T, D>,
-    M: Unsigned,
-    N: Unsigned,
     D: Fallible + ?Sized,
     D::Error: Source,
 {
     fn deserialize_with(
         archived: &ArchivedVec<ArchivedVec<T::Archived>>,
         deserializer: &mut D,
-    ) -> Result<VariableList<VariableList<T, M>, N>, D::Error> {
+    ) -> Result<SszList<SszList<T, M>, N>, D::Error> {
         let mut outer = Vec::with_capacity(archived.len());
         for inner_archived in archived.iter() {
             let inner_vec: Vec<T> =
                 Deserialize::<Vec<T>, D>::deserialize(inner_archived, deserializer)?;
-            let inner = VariableList::new(inner_vec)
+            let inner = SszList::try_from(inner_vec)
                 .map_err(|e| <D::Error as Source>::new(SszError(format!("{e:?}"))))?;
             outer.push(inner);
         }
-        VariableList::new(outer).map_err(|e| <D::Error as Source>::new(SszError(format!("{e:?}"))))
+        SszList::try_from(outer).map_err(|e| <D::Error as Source>::new(SszError(format!("{e:?}"))))
     }
 }

--- a/crates/stateless-validator-common/src/rkyv_wrappers.rs
+++ b/crates/stateless-validator-common/src/rkyv_wrappers.rs
@@ -32,9 +32,9 @@ impl core::error::Error for SszError {}
 /// On serialization, the inner slice is serialized as a Vec.
 /// On deserialization, the Vec is converted back to `SszList`.
 #[derive(Debug)]
-pub struct AsVariableList;
+pub struct AsSszList;
 
-impl<T, const N: usize> ArchiveWith<SszList<T, N>> for AsVariableList
+impl<T, const N: usize> ArchiveWith<SszList<T, N>> for AsSszList
 where
     T: Archive,
 {
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<T, const N: usize, S> SerializeWith<SszList<T, N>, S> for AsVariableList
+impl<T, const N: usize, S> SerializeWith<SszList<T, N>, S> for AsSszList
 where
     T: Serialize<S>,
     S: Fallible + Allocator + Writer + ?Sized,
@@ -59,8 +59,7 @@ where
     }
 }
 
-impl<T, const N: usize, D> DeserializeWith<ArchivedVec<T::Archived>, SszList<T, N>, D>
-    for AsVariableList
+impl<T, const N: usize, D> DeserializeWith<ArchivedVec<T::Archived>, SszList<T, N>, D> for AsSszList
 where
     T: Archive,
     T::Archived: Deserialize<T, D>,
@@ -83,10 +82,9 @@ where
 ///
 /// Serializes as `Vec<Vec<T>>` and reconstructs on deserialization.
 #[derive(Debug)]
-pub struct AsNestedVariableList;
+pub struct AsNestedSszList;
 
-impl<T, const M: usize, const N: usize> ArchiveWith<SszList<SszList<T, M>, N>>
-    for AsNestedVariableList
+impl<T, const M: usize, const N: usize> ArchiveWith<SszList<SszList<T, M>, N>> for AsNestedSszList
 where
     T: Archive,
 {
@@ -103,7 +101,7 @@ where
 }
 
 impl<T, const M: usize, const N: usize, S> SerializeWith<SszList<SszList<T, M>, N>, S>
-    for AsNestedVariableList
+    for AsNestedSszList
 where
     T: Serialize<S>,
     S: Fallible + Allocator + Writer + ?Sized,
@@ -139,7 +137,7 @@ impl<T: Serialize<S>, S: Fallible + Allocator + Writer + ?Sized> Serialize<S>
 
 impl<T, const M: usize, const N: usize, D>
     DeserializeWith<ArchivedVec<ArchivedVec<T::Archived>>, SszList<SszList<T, M>, N>, D>
-    for AsNestedVariableList
+    for AsNestedSszList
 where
     T: Archive,
     T::Archived: Deserialize<T, D>,

--- a/crates/stateless-validator-common/src/rkyv_wrappers.rs
+++ b/crates/stateless-validator-common/src/rkyv_wrappers.rs
@@ -6,6 +6,7 @@
 use alloc::{format, string::String, vec::Vec};
 use core::{fmt, ops::Deref};
 
+use libssz_types::SszList;
 use rkyv::{
     Archive, Deserialize, Place, Serialize,
     rancor::{Fallible, Source},
@@ -13,7 +14,6 @@ use rkyv::{
     vec::{ArchivedVec, VecResolver},
     with::{ArchiveWith, DeserializeWith, SerializeWith},
 };
-use libssz_types::SszList;
 
 /// Simple error wrapper for `libssz_types` errors which don't implement `std::error::Error`.
 #[derive(Debug)]
@@ -41,11 +41,7 @@ where
     type Archived = ArchivedVec<T::Archived>;
     type Resolver = VecResolver;
 
-    fn resolve_with(
-        field: &SszList<T, N>,
-        resolver: Self::Resolver,
-        out: Place<Self::Archived>,
-    ) {
+    fn resolve_with(field: &SszList<T, N>, resolver: Self::Resolver, out: Place<Self::Archived>) {
         ArchivedVec::resolve_from_slice(field.deref(), resolver, out);
     }
 }
@@ -117,10 +113,7 @@ where
         serializer: &mut S,
     ) -> Result<Self::Resolver, S::Error> {
         let vecs: Vec<&[T]> = field.iter().map(|inner| inner.deref()).collect();
-        ArchivedVec::serialize_from_iter(
-            vecs.iter().map(|slice| SliceAsVec(slice)),
-            serializer,
-        )
+        ArchivedVec::serialize_from_iter(vecs.iter().map(|slice| SliceAsVec(slice)), serializer)
     }
 }
 

--- a/crates/stateless-validator-common/src/serde_wrappers.rs
+++ b/crates/stateless-validator-common/src/serde_wrappers.rs
@@ -32,8 +32,9 @@ pub mod bytes_array {
 
 /// Serialize an `SszList<T, N>` as `Vec<T>`.
 pub mod ssz_list {
-    use super::*;
     use serde::{Deserialize, Serialize, de::Error};
+
+    use super::*;
 
     /// Serialize an `SszList<T, N>` as a sequence.
     pub fn serialize<T, S: Serializer, const N: usize>(
@@ -60,8 +61,9 @@ pub mod ssz_list {
 
 /// Serialize an `SszList<SszList<T, M>, N>` as `Vec<Vec<T>>`.
 pub mod nested_ssz_list {
-    use super::*;
     use serde::{Deserialize, Serialize, de::Error};
+
+    use super::*;
 
     /// Serialize a nested `SszList` as a nested sequence.
     pub fn serialize<T, S: Serializer, const M: usize, const N: usize>(

--- a/crates/stateless-validator-common/src/serde_wrappers.rs
+++ b/crates/stateless-validator-common/src/serde_wrappers.rs
@@ -1,8 +1,12 @@
-//! Serde wrappers for byte arrays.
+//! Serde wrappers for byte arrays and `libssz_types` containers.
 //!
 //! Provides helpers for serializing fixed-size byte arrays using serde_with::Bytes,
 //! which is efficient for binary formats and uses byte sequences for human-readable formats.
 
+use alloc::{format, vec::Vec};
+use core::ops::Deref;
+
+use libssz_types::SszList;
 use serde::{Deserializer, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
@@ -23,5 +27,68 @@ pub mod bytes_array {
         deserializer: D,
     ) -> Result<[u8; N], D::Error> {
         serde_with::Bytes::deserialize_as(deserializer)
+    }
+}
+
+/// Serialize an `SszList<T, N>` as `Vec<T>`.
+pub mod ssz_list {
+    use super::*;
+    use serde::{Deserialize, Serialize, de::Error};
+
+    /// Serialize an `SszList<T, N>` as a sequence.
+    pub fn serialize<T, S: Serializer, const N: usize>(
+        list: &SszList<T, N>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+    {
+        list.deref().serialize(serializer)
+    }
+
+    /// Deserialize a sequence into `SszList<T, N>`.
+    pub fn deserialize<'de, T, D: Deserializer<'de>, const N: usize>(
+        deserializer: D,
+    ) -> Result<SszList<T, N>, D::Error>
+    where
+        T: Deserialize<'de>,
+    {
+        let vec = Vec::<T>::deserialize(deserializer)?;
+        SszList::try_from(vec).map_err(|err| D::Error::custom(format!("{err:?}")))
+    }
+}
+
+/// Serialize an `SszList<SszList<T, M>, N>` as `Vec<Vec<T>>`.
+pub mod nested_ssz_list {
+    use super::*;
+    use serde::{Deserialize, Serialize, de::Error};
+
+    /// Serialize a nested `SszList` as a nested sequence.
+    pub fn serialize<T, S: Serializer, const M: usize, const N: usize>(
+        list: &SszList<SszList<T, M>, N>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        T: Serialize,
+    {
+        let nested: Vec<&[T]> = list.iter().map(|inner| inner.deref()).collect();
+        nested.serialize(serializer)
+    }
+
+    /// Deserialize a nested sequence into `SszList<SszList<T, M>, N>`.
+    pub fn deserialize<'de, T, D: Deserializer<'de>, const M: usize, const N: usize>(
+        deserializer: D,
+    ) -> Result<SszList<SszList<T, M>, N>, D::Error>
+    where
+        T: Deserialize<'de>,
+    {
+        let nested = Vec::<Vec<T>>::deserialize(deserializer)?;
+        let mut outer = Vec::with_capacity(nested.len());
+        for inner in nested {
+            let inner =
+                SszList::try_from(inner).map_err(|err| D::Error::custom(format!("{err:?}")))?;
+            outer.push(inner);
+        }
+        SszList::try_from(outer).map_err(|err| D::Error::custom(format!("{err:?}")))
     }
 }

--- a/crates/stateless-validator-ethrex/src/guest.rs
+++ b/crates/stateless-validator-ethrex/src/guest.rs
@@ -161,7 +161,7 @@ mod test {
             fee_recipient: [2; 20],
             state_root: [3; 32],
             receipts_root: [4; 32],
-            logs_bloom: Default::default(),
+            logs_bloom: [0; 256],
             prev_randao: [5; 32],
             block_number: 1,
             gas_limit: 2,

--- a/crates/stateless-validator-ethrex/src/new_payload_request.rs
+++ b/crates/stateless-validator-ethrex/src/new_payload_request.rs
@@ -78,13 +78,13 @@ impl From<ExecutionPayloadV1> for ExecutionPayload {
             gas_limit: payload.gas_limit,
             gas_used: payload.gas_used,
             timestamp: payload.timestamp,
-            extra_data: Bytes::from(Vec::from(payload.extra_data)),
+            extra_data: Bytes::from(payload.extra_data.into_inner()),
             base_fee_per_gas: base_fee_to_u64(&payload.base_fee_per_gas),
             block_hash: H256::from(payload.block_hash),
             transactions: payload
                 .transactions
                 .into_iter()
-                .map(|t| EncodedTransaction(Bytes::from(Vec::from(t))))
+                .map(|t| EncodedTransaction(Bytes::from(t.into_inner())))
                 .collect(),
             withdrawals: None,
             blob_gas_used: None,
@@ -106,13 +106,13 @@ impl From<ExecutionPayloadV2> for ExecutionPayload {
             gas_limit: payload.gas_limit,
             gas_used: payload.gas_used,
             timestamp: payload.timestamp,
-            extra_data: Bytes::from(Vec::from(payload.extra_data)),
+            extra_data: Bytes::from(payload.extra_data.into_inner()),
             base_fee_per_gas: base_fee_to_u64(&payload.base_fee_per_gas),
             block_hash: H256::from(payload.block_hash),
             transactions: payload
                 .transactions
                 .into_iter()
-                .map(|t| EncodedTransaction(Bytes::from(Vec::from(t))))
+                .map(|t| EncodedTransaction(Bytes::from(t.into_inner())))
                 .collect(),
             withdrawals: Some(
                 payload
@@ -140,13 +140,13 @@ impl From<ExecutionPayloadV3> for ExecutionPayload {
             gas_limit: payload.gas_limit,
             gas_used: payload.gas_used,
             timestamp: payload.timestamp,
-            extra_data: Bytes::from(Vec::from(payload.extra_data)),
+            extra_data: Bytes::from(payload.extra_data.into_inner()),
             base_fee_per_gas: base_fee_to_u64(&payload.base_fee_per_gas),
             block_hash: H256::from(payload.block_hash),
             transactions: payload
                 .transactions
                 .into_iter()
-                .map(|t| EncodedTransaction(Bytes::from(Vec::from(t))))
+                .map(|t| EncodedTransaction(Bytes::from(t.into_inner())))
                 .collect(),
             withdrawals: Some(
                 payload

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -32,14 +32,6 @@ reth-evm-ethereum.workspace = true
 reth-primitives-traits.workspace = true
 stateless.workspace = true
 
-# lighthouse
-tree_hash.workspace = true
-tree_hash_derive.workspace = true
-
-# ssz
-ssz_types.workspace = true
-ethereum_ssz.workspace = true
-
 # mpt
 tries.workspace = true
 

--- a/crates/stateless-validator-reth/src/host.rs
+++ b/crates/stateless-validator-reth/src/host.rs
@@ -14,13 +14,12 @@ use reth_chainspec::ChainSpec;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm_ethereum::EthEvmConfig;
 use reth_primitives_traits::Block;
-use ssz_types::{FixedVector, VariableList};
 pub use stateless::StatelessInput;
 use stateless::{UncompressedPublicKey, stateless_validation_with_trie};
 pub use stateless_validator_common::guest::StatelessValidatorOutput;
 use stateless_validator_common::new_payload_request::{
-    ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ForkName, NewPayloadRequest,
-    Transaction as Tx, Transactions, Withdrawal, Withdrawals,
+    ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ExtraData, ForkName,
+    NewPayloadRequest, Transaction as Tx, Transactions, Withdrawal, Withdrawals,
 };
 use tries::zeth::SparseState;
 
@@ -113,11 +112,21 @@ pub fn to_new_payload_request(
             .map(|tx| {
                 let mut buf = Vec::new();
                 tx.encode_2718(&mut buf);
-                Tx::from(buf)
+                Tx::try_from(buf)
             })
-            .collect();
-        Transactions::from(txs)
+            .collect::<Result<_, _>>()
+            .map_err(|err| {
+                anyhow::anyhow!("transaction length should be within bounds: {err:?}")
+            })?;
+        txs.try_into()
+            .map_err(|err| anyhow::anyhow!("transactions count should be within bounds: {err:?}"))?
     };
+    let logs_bloom = *header.logs_bloom.data();
+    let extra_data: ExtraData = header
+        .extra_data
+        .to_vec()
+        .try_into()
+        .map_err(|err| anyhow::anyhow!("extra data length should be within bounds: {err:?}"))?;
 
     // Helper to convert alloy withdrawal to our neutral type
     let convert_withdrawal = |w: &alloy_eips::eip4895::Withdrawal| Withdrawal {
@@ -125,6 +134,15 @@ pub fn to_new_payload_request(
         validator_index: w.validator_index,
         address: w.address.0.0,
         amount: w.amount,
+    };
+    let build_withdrawals = || -> anyhow::Result<Withdrawals> {
+        let wdls: Vec<Withdrawal> = body
+            .withdrawals
+            .as_ref()
+            .map(|ws| ws.iter().map(convert_withdrawal).collect())
+            .unwrap_or_default();
+        wdls.try_into()
+            .map_err(|err| anyhow::anyhow!("withdrawals length should be within bounds: {err:?}"))
     };
 
     match fork {
@@ -134,13 +152,13 @@ pub fn to_new_payload_request(
                 fee_recipient: header.beneficiary.0.0,
                 state_root: header.state_root.0,
                 receipts_root: header.receipts_root.0,
-                logs_bloom: FixedVector::from(header.logs_bloom.0.to_vec()),
+                logs_bloom,
                 prev_randao: header.mix_hash.0,
                 block_number: header.number,
                 gas_limit: header.gas_limit,
                 gas_used: header.gas_used,
                 timestamp: header.timestamp,
-                extra_data: VariableList::from(header.extra_data.to_vec()),
+                extra_data: extra_data.clone(),
                 base_fee_per_gas: U256::from(header.base_fee_per_gas.unwrap_or_default())
                     .to_le_bytes(),
                 block_hash: stateless_input.block.hash_slow().0,
@@ -149,27 +167,20 @@ pub fn to_new_payload_request(
             Ok(NewPayloadRequest::new_bellatrix(payload))
         }
         ForkName::Capella => {
-            let withdrawals: Withdrawals = {
-                let wdls: Vec<Withdrawal> = body
-                    .withdrawals
-                    .as_ref()
-                    .map(|ws| ws.iter().map(convert_withdrawal).collect())
-                    .unwrap_or_default();
-                Withdrawals::from(wdls)
-            };
+            let withdrawals = build_withdrawals()?;
 
             let payload = ExecutionPayloadV2 {
                 parent_hash: header.parent_hash.0,
                 fee_recipient: header.beneficiary.0.0,
                 state_root: header.state_root.0,
                 receipts_root: header.receipts_root.0,
-                logs_bloom: FixedVector::from(header.logs_bloom.0.to_vec()),
+                logs_bloom,
                 prev_randao: header.mix_hash.0,
                 block_number: header.number,
                 gas_limit: header.gas_limit,
                 gas_used: header.gas_used,
                 timestamp: header.timestamp,
-                extra_data: VariableList::from(header.extra_data.to_vec()),
+                extra_data: extra_data.clone(),
                 base_fee_per_gas: U256::from(header.base_fee_per_gas.unwrap_or_default())
                     .to_le_bytes(),
                 block_hash: stateless_input.block.hash_slow().0,
@@ -179,27 +190,20 @@ pub fn to_new_payload_request(
             Ok(NewPayloadRequest::new_capella(payload))
         }
         ForkName::Deneb => {
-            let withdrawals: Withdrawals = {
-                let wdls: Vec<Withdrawal> = body
-                    .withdrawals
-                    .as_ref()
-                    .map(|ws| ws.iter().map(convert_withdrawal).collect())
-                    .unwrap_or_default();
-                Withdrawals::from(wdls)
-            };
+            let withdrawals = build_withdrawals()?;
 
             let payload = ExecutionPayloadV3 {
                 parent_hash: header.parent_hash.0,
                 fee_recipient: header.beneficiary.0.0,
                 state_root: header.state_root.0,
                 receipts_root: header.receipts_root.0,
-                logs_bloom: FixedVector::from(header.logs_bloom.0.to_vec()),
+                logs_bloom,
                 prev_randao: header.mix_hash.0,
                 block_number: header.number,
                 gas_limit: header.gas_limit,
                 gas_used: header.gas_used,
                 timestamp: header.timestamp,
-                extra_data: VariableList::from(header.extra_data.to_vec()),
+                extra_data: extra_data.clone(),
                 base_fee_per_gas: U256::from(header.base_fee_per_gas.unwrap_or_default())
                     .to_le_bytes(),
                 block_hash: stateless_input.block.hash_slow().0,
@@ -226,27 +230,20 @@ pub fn to_new_payload_request(
             NewPayloadRequest::new_deneb(payload, versioned_hashes, parent_beacon_block_root)
         }
         ForkName::Electra | ForkName::Fulu => {
-            let withdrawals: Withdrawals = {
-                let wdls: Vec<Withdrawal> = body
-                    .withdrawals
-                    .as_ref()
-                    .map(|ws| ws.iter().map(convert_withdrawal).collect())
-                    .unwrap_or_default();
-                Withdrawals::from(wdls)
-            };
+            let withdrawals = build_withdrawals()?;
 
             let payload = ExecutionPayloadV3 {
                 parent_hash: header.parent_hash.0,
                 fee_recipient: header.beneficiary.0.0,
                 state_root: header.state_root.0,
                 receipts_root: header.receipts_root.0,
-                logs_bloom: FixedVector::from(header.logs_bloom.0.to_vec()),
+                logs_bloom,
                 prev_randao: header.mix_hash.0,
                 block_number: header.number,
                 gas_limit: header.gas_limit,
                 gas_used: header.gas_used,
                 timestamp: header.timestamp,
-                extra_data: VariableList::from(header.extra_data.to_vec()),
+                extra_data,
                 base_fee_per_gas: U256::from(header.base_fee_per_gas.unwrap_or_default())
                     .to_le_bytes(),
                 block_hash: stateless_input.block.hash_slow().0,

--- a/crates/stateless-validator-reth/src/host.rs
+++ b/crates/stateless-validator-reth/src/host.rs
@@ -320,7 +320,7 @@ mod test {
             fee_recipient: [2; 20],
             state_root: [3; 32],
             receipts_root: [4; 32],
-            logs_bloom: Default::default(),
+            logs_bloom: [0; 256],
             prev_randao: [5; 32],
             block_number: 1,
             gas_limit: 2,

--- a/crates/stateless-validator-reth/src/new_payload_request.rs
+++ b/crates/stateless-validator-reth/src/new_payload_request.rs
@@ -163,13 +163,13 @@ fn convert_v1_to_alloy(payload: ExecutionPayloadV1) -> AlloyExecutionPayloadV1 {
         gas_limit: payload.gas_limit,
         gas_used: payload.gas_used,
         timestamp: payload.timestamp,
-        extra_data: Bytes::from(Vec::from(payload.extra_data)),
+        extra_data: Bytes::from(payload.extra_data.into_inner()),
         base_fee_per_gas: U256::from_le_bytes(payload.base_fee_per_gas),
         block_hash: B256::from(payload.block_hash),
         transactions: payload
             .transactions
             .into_iter()
-            .map(|tx| Bytes::from(Vec::from(tx)))
+            .map(|tx| Bytes::from(tx.into_inner()))
             .collect(),
     }
 }
@@ -188,13 +188,13 @@ fn convert_v2_to_alloy(
         gas_limit: payload.gas_limit,
         gas_used: payload.gas_used,
         timestamp: payload.timestamp,
-        extra_data: Bytes::from(Vec::from(payload.extra_data)),
+        extra_data: Bytes::from(payload.extra_data.into_inner()),
         base_fee_per_gas: U256::from_le_bytes(payload.base_fee_per_gas),
         block_hash: B256::from(payload.block_hash),
         transactions: payload
             .transactions
             .into_iter()
-            .map(|tx| Bytes::from(Vec::from(tx)))
+            .map(|tx| Bytes::from(tx.into_inner()))
             .collect(),
     };
 
@@ -221,13 +221,13 @@ fn convert_v2_to_alloy_from_v3(
         gas_limit: payload.gas_limit,
         gas_used: payload.gas_used,
         timestamp: payload.timestamp,
-        extra_data: Bytes::from(Vec::from(payload.extra_data)),
+        extra_data: Bytes::from(payload.extra_data.into_inner()),
         base_fee_per_gas: U256::from_le_bytes(payload.base_fee_per_gas),
         block_hash: B256::from(payload.block_hash),
         transactions: payload
             .transactions
             .into_iter()
-            .map(|tx| Bytes::from(Vec::from(tx)))
+            .map(|tx| Bytes::from(tx.into_inner()))
             .collect(),
     };
 


### PR DESCRIPTION
This PR switches from Ligthouse SSZ library to Lambdaclass new [SSZ library](https://github.com/lambdaclass/libssz). 

This has many benefits:
1. `libssz` has native `no_std` support, so it allows us to now run Airbender.
2. From the measurements I've done with Zisk cost calculator, the hash tree root for the output commitment is 2x faster. Technically, this should result in an overall proving speedup of ~5% (previous hash tree root influence in total proving time was ~10%).
3. Much less indirect dependencies, and also remove one `ethereum_hashing` patch I had to do, so less complexity/forks.

Fixes https://github.com/eth-act/ere-guests/issues/8