### PR TITLE
Update to latest ethrex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ dependencies = [
 [[package]]
 name = "ethrex-blockchain"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "crossbeam 0.8.4",
@@ -2130,7 +2130,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2163,7 +2163,7 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2186,7 +2186,7 @@ dependencies = [
 [[package]]
 name = "ethrex-guest-program"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bitvec",
  "bytes",
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "ethrex-metrics"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "ethrex-p2p"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2314,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2328,7 +2328,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rpc"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "axum",
  "axum-extra",
@@ -2367,7 +2367,7 @@ dependencies = [
 [[package]]
 name = "ethrex-storage"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2392,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2416,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bincode 1.3.3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,11 @@ rust_2018_idioms = { level = "deny", priority = -1 }
 unnameable_types = "warn"
 unreachable_pub = "warn"
 unused_must_use = "deny"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(zisk_hints)', 'cfg(zisk_hints_debug)', 'cfg(target_vendor, values("zisk"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(zisk_hints)',
+    'cfg(zisk_hints_debug)',
+    'cfg(target_vendor, values("zisk"))',
+] }
 
 [workspace.lints.rustdoc]
 all = "warn"
@@ -79,19 +83,22 @@ stateless = { git = "https://github.com/paradigmxyz/stateless", rev = "ed189a519
 tries = { git = "https://github.com/paradigmxyz/stateless", rev = "ed189a51931e8589102f3139d48fdbb3bbe4c1f7", default-features = false }
 
 # ethrex
-# FIXME: Update to upstream when https://github.com/lambdaclass/ethrex/pull/6392 is resolved.
-ethrex-common = { git = "https://github.com/han0110/ethrex.git", rev = "b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192", default-features = false }
-ethrex-crypto = { git = "https://github.com/han0110/ethrex.git", rev = "b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192", default-features = false }
-ethrex-guest-program = { git = "https://github.com/han0110/ethrex.git", rev = "b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192", default-features = false }
-ethrex-rlp = { git = "https://github.com/han0110/ethrex.git", rev = "b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192", default-features = false }
-ethrex-rpc = { git = "https://github.com/han0110/ethrex.git", rev = "b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192", default-features = false }
-ethrex-vm = { git = "https://github.com/han0110/ethrex.git", rev = "b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192", default-features = false }
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6", default-features = false }
+ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex.git", rev = "33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6", default-features = false }
+ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6", default-features = false }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", rev = "33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6", default-features = false }
+ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", rev = "33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6", default-features = false }
+ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", rev = "33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6", default-features = false }
 
 # ssz
 libssz = { version = "0.2.1", default-features = false, features = ["alloc"] }
 libssz_derive = { package = "libssz-derive", version = "0.2.1" }
-libssz_merkle = { package = "libssz-merkle", version = "0.2.1", default-features = false, features = ["alloc"] }
-libssz_types = { package = "libssz-types", version = "0.2.1", default-features = false, features = ["alloc"] }
+libssz_merkle = { package = "libssz-merkle", version = "0.2.1", default-features = false, features = [
+    "alloc",
+] }
+libssz_types = { package = "libssz-types", version = "0.2.1", default-features = false, features = [
+    "alloc",
+] }
 
 # ere
 ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1202,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "ethrex-guest-program"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bitvec",
  "bytes",
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1330,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bincode",
  "bytes",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "ethrex-guest-program"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1147,7 +1147,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bitvec",
  "bytes",
@@ -1195,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1209,7 +1209,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1233,7 +1233,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bincode",
  "bytes",

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -1054,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "ethrex-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1087,7 +1087,7 @@ dependencies = [
 [[package]]
 name = "ethrex-crypto"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1107,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "ethrex-guest-program"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1126,7 +1126,7 @@ dependencies = [
 [[package]]
 name = "ethrex-l2-common"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "ethrex-levm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bitvec",
  "bytes",
@@ -1173,7 +1173,7 @@ dependencies = [
 [[package]]
 name = "ethrex-rlp"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "ethrex-trie"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "ethrex-vm"
 version = "9.0.0"
-source = "git+https://github.com/han0110/ethrex.git?rev=b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192#b9d3ef6924633ade5cc5e8f41b83f8ff7b3ec192"
+source = "git+https://github.com/lambdaclass/ethrex.git?rev=33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6#33695e2b3d5bb7ca50cf8b0bde31fd80bd59a5f6"
 dependencies = [
  "bincode",
  "bytes",

--- a/crates/stateless-validator-ethrex/src/execution_payload.rs
+++ b/crates/stateless-validator-ethrex/src/execution_payload.rs
@@ -9,6 +9,7 @@ use ethrex_common::{
         compute_withdrawals_root,
     },
 };
+use ethrex_crypto::Crypto;
 use ethrex_rlp::error::RLPDecodeError;
 
 #[derive(Clone, Debug)]
@@ -43,6 +44,7 @@ impl ExecutionPayload {
         self,
         parent_beacon_block_root: Option<H256>,
         requests_hash: Option<H256>,
+        crypto: &dyn Crypto,
     ) -> Result<Block, RLPDecodeError> {
         let body = BlockBody {
             transactions: self
@@ -58,7 +60,7 @@ impl ExecutionPayload {
             ommers_hash: *DEFAULT_OMMERS_HASH,
             coinbase: self.fee_recipient,
             state_root: self.state_root,
-            transactions_root: compute_transactions_root(&body.transactions),
+            transactions_root: compute_transactions_root(&body.transactions, crypto),
             receipts_root: self.receipts_root,
             logs_bloom: self.logs_bloom,
             difficulty: 0.into(),
@@ -73,7 +75,7 @@ impl ExecutionPayload {
             withdrawals_root: body
                 .withdrawals
                 .as_ref()
-                .map(|w| compute_withdrawals_root(w)),
+                .map(|w| compute_withdrawals_root(w, crypto)),
             blob_gas_used: self.blob_gas_used,
             excess_blob_gas: self.excess_blob_gas,
             parent_beacon_block_root,

--- a/crates/stateless-validator-ethrex/src/guest.rs
+++ b/crates/stateless-validator-ethrex/src/guest.rs
@@ -132,7 +132,7 @@ impl StatelessValidatorEthrexGuest {
     ) -> GuestOutput<Self> {
         let block_res = P::cycle_scope("new_payload_request_to_block", || {
             let hasher = EthrexSha256Hasher::new(crypto.as_ref());
-            get_block_from_new_payload_request(input.new_payload_request, &hasher)
+            get_block_from_new_payload_request(input.new_payload_request, &hasher, crypto.as_ref())
         });
         let block = match block_res {
             Ok(block) => block,

--- a/crates/stateless-validator-ethrex/src/new_payload_request.rs
+++ b/crates/stateless-validator-ethrex/src/new_payload_request.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{Context, Result};
 use ethrex_common::{Address, Bloom, Bytes, H256, types::Block};
+use ethrex_crypto::Crypto;
 use libssz_merkle::Sha256Hasher;
 use stateless_validator_common::new_payload_request::{
     ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, NewPayloadRequest, Withdrawal,
@@ -17,6 +18,7 @@ use crate::execution_payload::{
 pub fn get_block_from_new_payload_request(
     req: NewPayloadRequest,
     hasher: &impl Sha256Hasher,
+    crypto: &dyn Crypto,
 ) -> Result<Block> {
     match req {
         NewPayloadRequest::Bellatrix(b) => {
@@ -24,7 +26,7 @@ pub fn get_block_from_new_payload_request(
             validate_execution_payload_v1(&payload).context("V1 payload validation failed")?;
             let block = payload
                 .clone()
-                .into_block(None, None)
+                .into_block(None, None, crypto)
                 .context("into_block failed")?;
             validate_block_payload_v1_v2(&payload, &block)
                 .context("Block/Payload validation failed")?;
@@ -35,7 +37,7 @@ pub fn get_block_from_new_payload_request(
             validate_execution_payload_v2(&payload).context("V2 payload validation failed")?;
             let block = payload
                 .clone()
-                .into_block(None, None)
+                .into_block(None, None, crypto)
                 .context("into_block failed")?;
             validate_block_payload_v1_v2(&payload, &block)
                 .context("Block/Payload validation failed")?;
@@ -47,7 +49,7 @@ pub fn get_block_from_new_payload_request(
             validate_execution_payload_v3(&payload).context("V3 payload validation failed")?;
             let block = payload
                 .clone()
-                .into_block(parent_beacon_block_root, None)
+                .into_block(parent_beacon_block_root, None, crypto)
                 .context("into_block failed")?;
             validate_block_payload_v3(&payload, &block, &d.versioned_hashes)
                 .context("Block/Payload validation failed")?;
@@ -63,7 +65,7 @@ pub fn get_block_from_new_payload_request(
             validate_execution_payload_v3(&payload).context("V3 payload validation failed")?;
             let block = payload
                 .clone()
-                .into_block(parent_beacon_block_root, requests_hash)
+                .into_block(parent_beacon_block_root, requests_hash, crypto)
                 .context("into_block failed")?;
             validate_block_payload_v3(&payload, &block, &e.versioned_hashes)
                 .context("Block/Payload validation failed")?;


### PR DESCRIPTION
This PR updates Ethrex to the current latest commit, for two reasons:
1. Remove the fork we had that was waiting for https://github.com/lambdaclass/ethrex/pull/6392
2. Ethrex at that fork moment didn't use the Crypto provider to use keccak, thus all trie related work calling keccak wasn't using zkVM precompiles.

Did a quick `ziskemu` check and now the cost stops being blown up by the tries keccak load, which is how I noticed something was wrong reg point 2. above.