### PR TITLE
Add stateless-validator-debug crate with CLI for running guest fixtures natively

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,7 +315,7 @@ checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -390,7 +390,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -407,7 +407,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.116",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
@@ -423,7 +423,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "syn-solidity",
 ]
 
@@ -478,7 +478,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -497,7 +497,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
- "anstyle-parse",
+ "anstyle-parse 0.2.7",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse 1.0.0",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -516,6 +531,15 @@ name = "anstyle-parse"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -675,7 +699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -713,7 +737,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -773,7 +797,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -829,7 +853,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -856,7 +880,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1154,7 +1178,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1189,7 +1213,7 @@ checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1314,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1324,11 +1348,11 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream",
+ "anstream 1.0.0",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -1336,14 +1360,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1682,7 +1706,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1693,7 +1717,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1769,7 +1793,7 @@ checksum = "ef941ded77d15ca19b40374869ac6000af1c9f2a4c0f3d4c70926287e6364a8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1799,7 +1823,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1813,7 +1837,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.116",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -1846,7 +1870,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1896,7 +1920,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1961,7 +1985,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2573,7 +2597,7 @@ checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2690,7 +2714,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3294,7 +3318,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3600,7 +3624,7 @@ checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3630,7 +3654,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5297962ef19edda4ce33aaa484386e0a5b3d7f2f4e037cbeee00503ef6b29d33"
 dependencies = [
- "anstream",
+ "anstream 0.6.21",
  "anstyle",
  "clap",
  "escape8259",
@@ -3686,7 +3710,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3822,7 +3846,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3842,7 +3866,7 @@ checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3990,7 +4014,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4079,7 +4103,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4302,7 +4326,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4430,7 +4454,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4519,7 +4543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4583,7 +4607,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4673,7 +4697,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4713,7 +4737,7 @@ checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4724,9 +4748,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -4887,7 +4911,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5001,7 +5025,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.11.0#564ffa586845fa4a8b
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5556,7 +5580,7 @@ checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5906,7 +5930,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5973,7 +5997,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6349,6 +6373,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "stateless-validator-debug"
+version = "0.5.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "guest",
+ "serde",
+ "serde_json",
+ "stateless",
+ "stateless-validator-ethrex",
+ "stateless-validator-reth",
+]
+
+[[package]]
 name = "stateless-validator-ethrex"
 version = "0.5.0"
 dependencies = [
@@ -6432,7 +6470,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6467,9 +6505,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6485,7 +6523,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6505,7 +6543,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6585,7 +6623,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6596,7 +6634,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6707,7 +6745,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6864,7 +6902,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7216,7 +7254,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -7313,7 +7351,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7324,7 +7362,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7566,7 +7604,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7582,7 +7620,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7668,7 +7706,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7689,7 +7727,7 @@ checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7709,7 +7747,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7730,7 +7768,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7763,7 +7801,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.116",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6384,6 +6384,8 @@ dependencies = [
  "stateless",
  "stateless-validator-ethrex",
  "stateless-validator-reth",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
 
     # Guest libs
     "crates/block-encoding-length",
+    "crates/stateless-validator-debug",
     "crates/stateless-validator-common",
     "crates/stateless-validator-ethrex",
     "crates/stateless-validator-reth",
@@ -45,6 +46,7 @@ result_large_err = "allow"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
+clap = { version = "4.6.0", features = ["derive"] }
 once_cell = { version = "1.21", default-features = false }
 rkyv = { version = "0.8.10", default-features = false }
 serde = { version = "1.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Located in `crates/`, these provide reusable functionality for guest programs an
 - [`block-encoding-length`](crates/block-encoding-length) - SSZ block encoding length calculation benchmark
 - [`stateless-validator-ethrex`](crates/stateless-validator-ethrex) - Stateless validation using Ethrex
 - [`stateless-validator-reth`](crates/stateless-validator-reth) - Stateless validation using Reth
+- [`stateless-validator-debug`](crates/stateless-validator-debug) - CLI tool for running stateless validator guest fixtures natively
 
 ### Guest Programs
 

--- a/crates/stateless-validator-debug/Cargo.toml
+++ b/crates/stateless-validator-debug/Cargo.toml
@@ -13,6 +13,8 @@ anyhow.workspace = true
 clap.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 # reth
 stateless.workspace = true

--- a/crates/stateless-validator-debug/Cargo.toml
+++ b/crates/stateless-validator-debug/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "stateless-validator-debug"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+clap.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+
+# reth
+stateless.workspace = true
+
+# local
+guest.workspace = true
+stateless-validator-ethrex = { workspace = true, default-features = true, features = [
+    "host",
+] }
+stateless-validator-reth = { workspace = true, default-features = true, features = [
+    "host",
+] }

--- a/crates/stateless-validator-debug/src/lib.rs
+++ b/crates/stateless-validator-debug/src/lib.rs
@@ -17,6 +17,7 @@ use stateless_validator_ethrex::guest::{
 use stateless_validator_reth::guest::{
     StatelessValidatorOutput, StatelessValidatorRethGuest, StatelessValidatorRethInput,
 };
+use tracing_subscriber::EnvFilter;
 
 /// CLI options for the stateless validator debug runner.
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
@@ -30,6 +31,9 @@ pub struct Cli {
     /// Guest program to run.
     #[arg(long, value_enum)]
     pub guest: GuestKind,
+    /// Warn and continue when fixture success does not match guest output.
+    #[arg(long)]
+    pub allow_success_mismatch: bool,
     /// Path to a fixture file or directory.
     pub path: PathBuf,
 }
@@ -138,6 +142,7 @@ impl Platform for StdoutNoopPlatform {
 
 /// Entry point for the debug runner binary.
 pub fn main_entry() -> anyhow::Result<()> {
+    init_tracing();
     execute(Cli::parse(), |summary| println!("{summary}"))
 }
 
@@ -153,18 +158,47 @@ pub fn execute(cli: Cli, mut on_summary: impl FnMut(&RunSummary)) -> anyhow::Res
             .with_context(|| format!("failed to execute fixture {}", fixture_path.display()))?;
         on_summary(&summary);
 
-        if summary.actual_success != summary.expected_success {
-            bail!(
-                "fixture {} ({}) expected success={}, got success={}",
-                summary.fixture_name,
-                fixture_path.display(),
-                summary.expected_success,
-                summary.actual_success,
-            );
-        }
+        handle_success_mismatch(&summary, &fixture_path, cli.allow_success_mismatch)?;
     }
 
     Ok(())
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
+        )
+        .try_init();
+}
+
+fn handle_success_mismatch(
+    summary: &RunSummary,
+    fixture_path: &Path,
+    allow_success_mismatch: bool,
+) -> anyhow::Result<()> {
+    if summary.actual_success == summary.expected_success {
+        return Ok(());
+    }
+
+    if allow_success_mismatch {
+        tracing::warn!(
+            fixture_name = summary.fixture_name.as_str(),
+            fixture_path = %fixture_path.display(),
+            expected_success = summary.expected_success,
+            actual_success = summary.actual_success,
+            "fixture success mismatch",
+        );
+        return Ok(());
+    }
+
+    bail!(
+        "fixture {} ({}) expected success={}, got success={}",
+        summary.fixture_name,
+        fixture_path.display(),
+        summary.expected_success,
+        summary.actual_success,
+    );
 }
 
 /// Collects fixture file paths from a JSON file or a directory.

--- a/crates/stateless-validator-debug/src/lib.rs
+++ b/crates/stateless-validator-debug/src/lib.rs
@@ -1,0 +1,226 @@
+//! Host-side debug runner for stateless validator guest fixtures.
+
+use std::{
+    fs,
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, bail};
+use clap::{Parser, ValueEnum};
+use guest::{Guest, Platform};
+use serde::Deserialize;
+use stateless::StatelessInput;
+use stateless_validator_ethrex::guest::{
+    StatelessValidatorEthrexGuest, StatelessValidatorEthrexInput,
+};
+use stateless_validator_reth::guest::{
+    StatelessValidatorOutput, StatelessValidatorRethGuest, StatelessValidatorRethInput,
+};
+
+/// CLI options for the stateless validator debug runner.
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
+#[command(
+    name = "stateless-validator-debug",
+    about = "Run stateless validator guest fixtures directly on the host.",
+    long_about = None,
+    arg_required_else_help = true
+)]
+pub struct Cli {
+    /// Guest program to run.
+    #[arg(long, value_enum)]
+    pub guest: GuestKind,
+    /// Path to a fixture file or directory.
+    pub path: PathBuf,
+}
+
+/// Stateless validator guest selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum GuestKind {
+    /// Run the Reth stateless validator guest.
+    Reth,
+    /// Run the Ethrex stateless validator guest.
+    Ethrex,
+}
+
+impl GuestKind {
+    fn run_fixture(self, fixture: &StatelessValidatorFixture) -> anyhow::Result<RunSummary> {
+        let output: StatelessValidatorOutput = match self {
+            Self::Reth => {
+                let input =
+                    StatelessValidatorRethInput::new(&fixture.stateless_input, fixture.success)?;
+                StatelessValidatorRethGuest::compute::<StdoutNoopPlatform>(input)
+            }
+            Self::Ethrex => {
+                let input =
+                    StatelessValidatorEthrexInput::new(&fixture.stateless_input, fixture.success)?;
+                StatelessValidatorEthrexGuest::compute::<StdoutNoopPlatform>(input)
+            }
+        };
+
+        Ok(RunSummary {
+            fixture_name: fixture.name.clone(),
+            guest: self,
+            expected_success: fixture.success,
+            actual_success: output.successful_block_validation,
+            new_payload_request_root: output.new_payload_request_root,
+        })
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Reth => "reth",
+            Self::Ethrex => "ethrex",
+        }
+    }
+}
+
+/// Deserialized JSON fixture supported by the debug runner.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StatelessValidatorFixture {
+    /// Human-readable fixture identifier.
+    pub name: String,
+    /// Stateless input consumed by the host-side input builders.
+    pub stateless_input: StatelessInput,
+    /// Expected validation outcome.
+    pub success: bool,
+}
+
+/// Summary of one guest execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunSummary {
+    /// Name of the fixture that ran.
+    pub fixture_name: String,
+    /// Guest program that was executed.
+    pub guest: GuestKind,
+    /// Expected guest success from the fixture.
+    pub expected_success: bool,
+    /// Actual guest success reported by the guest output.
+    pub actual_success: bool,
+    /// The resulting new payload request root.
+    pub new_payload_request_root: [u8; 32],
+}
+
+impl std::fmt::Display for RunSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "fixture={} guest={} expected_success={} actual_success={} new_payload_request_root=0x{}",
+            self.fixture_name,
+            self.guest.as_str(),
+            self.expected_success,
+            self.actual_success,
+            encode_hex(&self.new_payload_request_root),
+        )
+    }
+}
+
+/// A no-op platform for host-side guest execution that forwards debug messages to stdout.
+#[derive(Debug)]
+pub struct StdoutNoopPlatform;
+
+impl Platform for StdoutNoopPlatform {
+    #[allow(unreachable_code)]
+    fn read_whole_input() -> impl std::ops::Deref<Target = [u8]> {
+        panic!("Can't read input in StdoutNoopPlatform");
+        &[] as &[u8]
+    }
+
+    fn write_whole_output(_: &[u8]) {
+        panic!("Can't write output in StdoutNoopPlatform");
+    }
+
+    fn print(message: &str) {
+        println!("{message}");
+        let _ = io::stdout().flush();
+    }
+}
+
+/// Entry point for the debug runner binary.
+pub fn main_entry() -> anyhow::Result<()> {
+    execute(Cli::parse(), |summary| println!("{summary}"))
+}
+
+/// Executes one or more fixtures and reports each summary via `on_summary`.
+pub fn execute(cli: Cli, mut on_summary: impl FnMut(&RunSummary)) -> anyhow::Result<()> {
+    let fixture_paths = collect_fixture_paths(&cli.path)?;
+
+    for fixture_path in fixture_paths {
+        let fixture = load_fixture(&fixture_path)?;
+        let summary = cli
+            .guest
+            .run_fixture(&fixture)
+            .with_context(|| format!("failed to execute fixture {}", fixture_path.display()))?;
+        on_summary(&summary);
+
+        if summary.actual_success != summary.expected_success {
+            bail!(
+                "fixture {} ({}) expected success={}, got success={}",
+                summary.fixture_name,
+                fixture_path.display(),
+                summary.expected_success,
+                summary.actual_success,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Collects fixture file paths from a JSON file or a directory.
+pub fn collect_fixture_paths(path: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    if path.is_file() {
+        if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            bail!(
+                "fixture file {} must have a .json extension",
+                path.display()
+            );
+        }
+        return Ok(vec![path.to_path_buf()]);
+    }
+
+    if !path.exists() {
+        bail!("path {} does not exist", path.display());
+    }
+
+    if !path.is_dir() {
+        bail!("path {} must be a file or directory", path.display());
+    }
+
+    let mut paths = fs::read_dir(path)
+        .with_context(|| format!("failed to read fixture directory {}", path.display()))?
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let entry_path = entry.path();
+            let file_type = entry.file_type().ok()?;
+            (file_type.is_file()
+                && entry_path.extension().and_then(|ext| ext.to_str()) == Some("json"))
+            .then_some(entry_path)
+        })
+        .collect::<Vec<_>>();
+    paths.sort();
+
+    if paths.is_empty() {
+        bail!("no JSON fixtures found in {}", path.display());
+    }
+
+    Ok(paths)
+}
+
+/// Loads one JSON fixture from disk.
+pub fn load_fixture(path: &Path) -> anyhow::Result<StatelessValidatorFixture> {
+    let bytes =
+        fs::read(path).with_context(|| format!("failed to read fixture {}", path.display()))?;
+    serde_json::from_slice(&bytes)
+        .with_context(|| format!("failed to deserialize fixture {}", path.display()))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+
+        let _ = write!(hex, "{byte:02x}");
+    }
+    hex
+}

--- a/crates/stateless-validator-debug/src/main.rs
+++ b/crates/stateless-validator-debug/src/main.rs
@@ -1,0 +1,5 @@
+//! CLI entry point for the stateless validator debug runner.
+
+fn main() -> anyhow::Result<()> {
+    stateless_validator_debug::main_entry()
+}


### PR DESCRIPTION
This PR:
- Add `stateless-validator-debug`, a CLI tool for running stateless validator guest fixtures directly on the host without needing a zkVM
- Supports both `--guest reth` and `--guest ethrex`, accepts a single JSON fixture file or a directory of fixtures
- Update README with the new crate

The main goal was to have a quick way to natively debug fixtures in guest programs. For example, I'm investigating some weird behaviour in a particular fixture, and it is quite helpful to have a way to run the guest natively, adding extra printlns or similar to figure out what is going on.

Usage:
```
cargo run -p stateless-validator-debug -- --guest reth path/to/fixtures/
cargo run -p stateless-validator-debug -- --guest ethrex fixture.json
```