### PR TITLE
feat: bump `ere` to `v0.8.0`

### DIFF
--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -85,7 +85,6 @@ jobs:
             --program-vk-path /output/${{ matrix.guest }}-${{ matrix.zkvm }}.vk
 
       - name: Upload artifact
-        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.guest }}-${{ matrix.zkvm }}

--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,36 +46,52 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Free up disk space
+        if: matrix.zkvm == 'zisk'
+        run: bash .github/scripts/free-up-disk-space.sh
+
       - name: Get Ere tag
         id: get_ere_tag
         run: |
-          ERE_TAG=$(cargo tree -p ere-platform-trait | head -n 1 | sed -E 's/ere-platform-trait v([0-9.]+) .*/\1/')
+          ERE_TAG=$(cargo tree -p ere-platform-core | head -n 1 | sed -E -e 's/.*\?rev=(.{7}).*/\1/' -e 's/.*\?tag=v([0-9.]+).*/\1/')
           echo "ere_tag=${ERE_TAG}" >> $GITHUB_OUTPUT
           echo "Ere tag: ${ERE_TAG}"
 
-      - name: Pull compiler image
+      - name: Pull Ere images
         run: |
           docker pull ghcr.io/eth-act/ere/ere-compiler-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }}
+          docker pull ghcr.io/eth-act/ere/ere-server-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }}
 
       - name: Compile guest
         run: |
           docker run \
+            -e RUST_LOG=info \
             -v $PWD:/ere-guests \
             -v $PWD/output:/output \
             ghcr.io/eth-act/ere/ere-compiler-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }} \
             --compiler-kind rust-customized \
             --guest-dir /ere-guests/bin/${{ matrix.guest }}/${{ matrix.zkvm }} \
             --output-dir /output \
-            --elf-name ${{ matrix.guest }}-${{ matrix.zkvm }}.elf \
-            --program-name ${{ matrix.guest }}-${{ matrix.zkvm }}
+            --elf-name ${{ matrix.guest }}-${{ matrix.zkvm }}.elf
+
+      - name: Generate program VK
+        run: |
+          docker run \
+            -e RUST_LOG=info \
+            -v $PWD/output:/output \
+            ghcr.io/eth-act/ere/ere-server-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }} \
+            --elf-path /output/${{ matrix.guest }}-${{ matrix.zkvm }}.elf \
+            keygen \
+            --program-vk-path /output/${{ matrix.guest }}-${{ matrix.zkvm }}.vk
 
       - name: Upload artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.guest }}-${{ matrix.zkvm }}
           path: |
             output/${{ matrix.guest }}-${{ matrix.zkvm }}.elf
-            output/${{ matrix.guest }}-${{ matrix.zkvm }}
+            output/${{ matrix.guest }}-${{ matrix.zkvm }}.vk
           if-no-files-found: error
 
   check-git-tag:
@@ -133,8 +154,8 @@ jobs:
             for elf_file in artifacts/$guest-*.elf; do
               if [ -f "$elf_file" ]; then
                 elf_name=$(basename "$elf_file")
-                program_name="${elf_name%.elf}"
-                echo "- [\`$elf_name\`]($RELEASE_URL/$elf_name) | [\`$program_name\`]($RELEASE_URL/$program_name)" >> release-body.md
+                program_vk_name="${elf_name%.elf}.vk"
+                echo "- [\`$elf_name\`]($RELEASE_URL/$elf_name) | [\`$program_vk_name\`]($RELEASE_URL/$program_vk_name)" >> release-body.md
               fi
             done
             echo "" >> release-body.md

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           .github/scripts/check-duplicate-pkg.sh \
-            --include '^(alloy|ethrex|ere|reth|revm)' \
+            --include '^(alloy|ethrex|ere|reth|revm|openvm|risc0|sp1|zisk)' \
             --exclude '^alloy-trie$' # Crate `mpt` depends on an older `alloy-trie` but it's okay.
 
   test:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1106,8 +1106,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "anyhow",
- "ere-io",
- "ere-zkvm-interface",
+ "bincode 2.0.1",
+ "ere-prover-core",
  "guest",
  "libssz",
  "libssz-derive",
@@ -1394,7 +1394,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1956,33 +1956,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-build-utils"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+name = "ere-catalog"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "cargo_metadata",
-]
-
-[[package]]
-name = "ere-common"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "ere-build-utils",
+ "ere-util-build",
  "serde",
  "strum",
 ]
 
 [[package]]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-compiler-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "ere-dockerized"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
  "anyhow",
- "ere-common",
- "ere-server",
- "ere-zkvm-interface",
- "serde",
+ "ere-catalog",
+ "ere-compiler-core",
+ "ere-prover-core",
+ "ere-server-client",
+ "ere-util-tokio",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1990,52 +1996,73 @@ dependencies = [
 ]
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode 2.0.1",
- "rkyv",
- "serde",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "ere-server"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "anyhow",
- "bincode 2.0.1",
- "ere-zkvm-interface",
- "prost",
- "serde",
- "thiserror 2.0.18",
- "tokio",
- "twirp",
-]
-
-[[package]]
-name = "ere-zkvm-interface"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+name = "ere-prover-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
  "anyhow",
  "auto_impl",
  "bincode 2.0.1",
  "clap",
+ "ere-codec",
+ "ere-verifier-core",
  "indexmap 2.13.0",
  "serde",
  "strum",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ere-server-api"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
+ "prost",
+ "serde",
+ "twirp",
+]
+
+[[package]]
+name = "ere-server-client"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
+ "bincode 2.0.1",
+ "ere-prover-core",
+ "ere-server-api",
+ "thiserror 2.0.18",
+ "twirp",
+]
+
+[[package]]
+name = "ere-util-build"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
+ "cargo_metadata",
+]
+
+[[package]]
+name = "ere-util-tokio"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "ere-verifier-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+dependencies = [
+ "auto_impl",
+ "ere-codec",
+ "serde",
 ]
 
 [[package]]
@@ -2760,8 +2787,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -3276,8 +3303,6 @@ dependencies = [
  "alloy-primitives",
  "block-encoding-length",
  "ere-dockerized",
- "ere-io",
- "ere-zkvm-interface",
  "flate2",
  "guest",
  "rayon",
@@ -4676,7 +4701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6347,6 +6372,8 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -6383,8 +6410,7 @@ dependencies = [
  "alloy-rlp",
  "anyhow",
  "bytes",
- "ere-io",
- "ere-zkvm-interface",
+ "ere-prover-core",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-guest-program",
@@ -6410,8 +6436,8 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "ere-io",
- "ere-zkvm-interface",
+ "bincode 2.0.1",
+ "ere-prover-core",
  "guest",
  "once_cell",
  "reth-chainspec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ result_large_err = "allow"
 
 [workspace.dependencies]
 anyhow = { version = "1.0", default-features = false }
+bincode = { version = "2.0.1", default-features = false }
 clap = { version = "4.6.0", features = ["derive"] }
 once_cell = { version = "1.21", default-features = false }
 rkyv = { version = "0.8.10", default-features = false }
@@ -103,10 +104,10 @@ libssz_types = { package = "libssz-types", version = "0.2.1", default-features =
 ] }
 
 # ere
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
-ere-io = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
-ere-platform-trait = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
-ere-zkvm-interface = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-codec = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
+ere-prover-core = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
 
 # local
 guest = { path = "crates/guest", default-features = false }

--- a/bin/block-encoding-length/airbender/Cargo.lock
+++ b/bin/block-encoding-length/airbender/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "ere-io",
+ "bincode",
  "guest",
  "libssz",
  "libssz-derive",
@@ -1111,30 +1111,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "riscv_common",
 ]
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "errno"
@@ -1294,8 +1287,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 

--- a/bin/block-encoding-length/airbender/Cargo.toml
+++ b/bin/block-encoding-length/airbender/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 # ere
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "custom_allocator",
 ] }
 

--- a/bin/block-encoding-length/openvm/Cargo.lock
+++ b/bin/block-encoding-length/openvm/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -642,7 +642,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "ere-io",
+ "bincode",
  "guest",
  "libssz",
  "libssz-derive",
@@ -1117,29 +1117,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "openvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1300,8 +1293,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 

--- a/bin/block-encoding-length/openvm/Cargo.toml
+++ b/bin/block-encoding-length/openvm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }
 

--- a/bin/block-encoding-length/risc0/Cargo.lock
+++ b/bin/block-encoding-length/risc0/Cargo.lock
@@ -830,7 +830,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "ere-io",
+ "bincode",
  "guest",
  "libssz",
  "libssz-derive",
@@ -1373,30 +1373,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "risc0-zkvm",
  "risc0-zkvm-platform",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1584,8 +1577,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 

--- a/bin/block-encoding-length/risc0/Cargo.toml
+++ b/bin/block-encoding-length/risc0/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }
 

--- a/bin/block-encoding-length/sp1/Cargo.lock
+++ b/bin/block-encoding-length/sp1/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -708,7 +708,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "ere-io",
+ "bincode 2.0.1",
  "guest",
  "libssz",
  "libssz-derive",
@@ -1239,29 +1239,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode 2.0.1",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "sp1-zkvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1557,8 +1550,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 

--- a/bin/block-encoding-length/sp1/Cargo.toml
+++ b/bin/block-encoding-length/sp1/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
 
 # local
 block-encoding-length = { path = "../../../crates/block-encoding-length" }

--- a/bin/block-encoding-length/zisk/Cargo.lock
+++ b/bin/block-encoding-length/zisk/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
- "ere-io",
+ "bincode 2.0.1",
  "guest",
  "libssz",
  "libssz-derive",
@@ -1039,7 +1039,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "clang-sys"
@@ -1573,28 +1573,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode 2.0.1",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "fnv",
  "ziskos",
 ]
@@ -1802,8 +1795,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -2106,12 +2099,12 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib-c"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "lib-float"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "libc"
@@ -2655,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "precompiles-helpers"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3274,7 +3267,7 @@ dependencies = [
 [[package]]
 name = "riscv"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "rlp"
@@ -4973,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "zisk-common"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -4998,7 +4991,7 @@ dependencies = [
 [[package]]
 name = "zisk-core"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "elf",
  "fields",
@@ -5018,12 +5011,12 @@ dependencies = [
 [[package]]
 name = "zisk-definitions"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "zisk-verifier"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "proofman-verifier",
 ]
@@ -5031,7 +5024,7 @@ dependencies = [
 [[package]]
 name = "ziskos"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",
@@ -5061,7 +5054,7 @@ dependencies = [
 [[package]]
 name = "ziskos-hints"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode 1.3.3",

--- a/bin/block-encoding-length/zisk/Cargo.toml
+++ b/bin/block-encoding-length/zisk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 # ere
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
 
 # local
 block-encoding-length = { path = "../../../crates/block-encoding-length" }

--- a/bin/empty/airbender/Cargo.lock
+++ b/bin/empty/airbender/Cargo.lock
@@ -3,50 +3,18 @@
 version = 4
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "crypto-common",
-]
-
-[[package]]
 name = "ere-platform-airbender"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "riscv_common",
 ]
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "panic-airbender"
@@ -59,15 +27,3 @@ dependencies = [
 name = "riscv_common"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/bin/empty/airbender/Cargo.toml
+++ b/bin/empty/airbender/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }

--- a/bin/empty/openvm/Cargo.lock
+++ b/bin/empty/openvm/Cargo.lock
@@ -21,25 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "crypto-common",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,30 +34,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
 name = "ere-platform-openvm"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "openvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -412,22 +380,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/bin/empty/openvm/Cargo.toml
+++ b/bin/empty/openvm/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }

--- a/bin/empty/risc0/Cargo.lock
+++ b/bin/empty/risc0/Cargo.lock
@@ -537,21 +537,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-platform-risc0"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "ere-platform-trait",
- "risc0-zkvm",
- "risc0-zkvm-platform",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+name = "ere-platform-risc0"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "digest",
+ "ere-platform-core",
+ "risc0-zkvm",
+ "risc0-zkvm-platform",
 ]
 
 [[package]]
@@ -963,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dca096030bb4c52f99b12abcfe3531ea93b17b95a12a5aeb06fbf8ee588a275"
+checksum = "1883f0c5d19b865f395209a137dcb29e56dc49951424967b8d0114c129f46e77"
 dependencies = [
  "anyhow",
  "borsh",
@@ -985,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "4.0.3"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1d23ef3648bb85b0bd37bc9f9f7d13f1a4388e5e779e18f7eea82b969e5dbc"
+checksum = "5f543c60287fece797a5da4209384ab1bfebd9644fcfe591e11b1aa85f1a02f8"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1001,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028cd26e1b1f7bdd964d2f1eac8f812d1872b6b8fd24f10804f07d916b90000e"
+checksum = "2347e909c6b2a65584b5898f3802eec5b8c1b4b45329edfdd8587b6a04dd3357"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1016,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ecd73a71ddce62eab8a28552ee182dc2ea08cdce2a3474a616a80bf2d6e9be"
+checksum = "61676419814a818fdb5e10066b13c5488b3f54aa9668794bd06c99bc91bff1f2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1034,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f2723fedace48c6c5a505bd8f97ac4e1712bc4cb769083e10536d862b66987"
+checksum = "b5b956a976b8ce4713694dcc6c370b522a42ccef4ba45da5b6e57dbf26cdb7b1"
 dependencies = [
  "bytemuck",
  "rand_core 0.9.3",
@@ -1044,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ff13f9b427254c5264e01aaa32e33f355525299b6829449295905778f3b1e8"
+checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1065,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf1f35f2ef61d8d86fdd06288c11d2f3bbf08f1af66b24ca0a1976ecbf324a1"
+checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1076,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb493b3f007f04a11106a001c66bca77338d0fc375766189fd7ca3a1e8c3700"
+checksum = "1f40d362a6c146ec6dc69208f539b92fd86e47b0dbc2083801423034a38155a2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1101,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39d9943fe71decea1e8b6a99480cefa33799ab08b5abfccd7e2a18fb07121c1"
+checksum = "22b7eafb5d85be59cbd9da83f662cf47d834f1b836e14f675d1530b12c666867"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1129,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaa10feba15828c788837ddde84b994393936d8f5715228627cfe8625122a40"
+checksum = "4db893788c416287e2e1a87e6b8f5302511a04a45329e699d6a32a16874fd24f"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/bin/empty/risc0/Cargo.toml
+++ b/bin/empty/risc0/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }

--- a/bin/empty/sp1/Cargo.lock
+++ b/bin/empty/sp1/Cargo.lock
@@ -321,20 +321,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ere-platform-sp1"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "ere-platform-trait",
- "sp1-zkvm",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+name = "ere-platform-sp1"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "digest",
+ "ere-platform-core",
+ "sp1-zkvm",
 ]
 
 [[package]]

--- a/bin/empty/sp1/Cargo.toml
+++ b/bin/empty/sp1/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }

--- a/bin/empty/zisk/Cargo.lock
+++ b/bin/empty/zisk/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "clang-sys"
@@ -762,19 +762,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "fnv",
  "ziskos",
 ]
@@ -1021,12 +1018,12 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "lib-c"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "lib-float"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "libc"
@@ -1358,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "precompiles-helpers"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1734,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "riscv"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "rustc-hash"
@@ -2924,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "zisk-common"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2949,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "zisk-core"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "elf",
  "fields",
@@ -2969,12 +2966,12 @@ dependencies = [
 [[package]]
 name = "zisk-definitions"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "zisk-verifier"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "proofman-verifier",
 ]
@@ -2982,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "ziskos"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3012,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "ziskos-hints"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode",

--- a/bin/empty/zisk/Cargo.toml
+++ b/bin/empty/zisk/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }

--- a/bin/panic/airbender/Cargo.lock
+++ b/bin/panic/airbender/Cargo.lock
@@ -3,50 +3,18 @@
 version = 4
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "crypto-common",
-]
-
-[[package]]
 name = "ere-platform-airbender"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "riscv_common",
 ]
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "panic-airbender"
@@ -59,15 +27,3 @@ dependencies = [
 name = "riscv_common"
 version = "0.1.0"
 source = "git+https://github.com/matter-labs/zksync-airbender?tag=v0.5.2#b93c285d292891f3c27a3cf0110be09cde30ac4f"
-
-[[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"

--- a/bin/panic/airbender/Cargo.toml
+++ b/bin/panic/airbender/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }

--- a/bin/panic/openvm/Cargo.lock
+++ b/bin/panic/openvm/Cargo.lock
@@ -21,55 +21,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "crypto-common",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
 name = "ere-platform-openvm"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "openvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -412,22 +380,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/bin/panic/openvm/Cargo.toml
+++ b/bin/panic/openvm/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }

--- a/bin/panic/risc0/Cargo.lock
+++ b/bin/panic/risc0/Cargo.lock
@@ -530,21 +530,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-platform-risc0"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "ere-platform-trait",
- "risc0-zkvm",
- "risc0-zkvm-platform",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+name = "ere-platform-risc0"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "digest",
+ "ere-platform-core",
+ "risc0-zkvm",
+ "risc0-zkvm-platform",
 ]
 
 [[package]]
@@ -963,9 +960,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dca096030bb4c52f99b12abcfe3531ea93b17b95a12a5aeb06fbf8ee588a275"
+checksum = "1883f0c5d19b865f395209a137dcb29e56dc49951424967b8d0114c129f46e77"
 dependencies = [
  "anyhow",
  "borsh",
@@ -985,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "4.0.3"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1d23ef3648bb85b0bd37bc9f9f7d13f1a4388e5e779e18f7eea82b969e5dbc"
+checksum = "5f543c60287fece797a5da4209384ab1bfebd9644fcfe591e11b1aa85f1a02f8"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1001,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028cd26e1b1f7bdd964d2f1eac8f812d1872b6b8fd24f10804f07d916b90000e"
+checksum = "2347e909c6b2a65584b5898f3802eec5b8c1b4b45329edfdd8587b6a04dd3357"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -1016,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ecd73a71ddce62eab8a28552ee182dc2ea08cdce2a3474a616a80bf2d6e9be"
+checksum = "61676419814a818fdb5e10066b13c5488b3f54aa9668794bd06c99bc91bff1f2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -1034,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f2723fedace48c6c5a505bd8f97ac4e1712bc4cb769083e10536d862b66987"
+checksum = "b5b956a976b8ce4713694dcc6c370b522a42ccef4ba45da5b6e57dbf26cdb7b1"
 dependencies = [
  "bytemuck",
  "rand_core 0.9.3",
@@ -1044,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ff13f9b427254c5264e01aaa32e33f355525299b6829449295905778f3b1e8"
+checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -1065,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf1f35f2ef61d8d86fdd06288c11d2f3bbf08f1af66b24ca0a1976ecbf324a1"
+checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -1076,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb493b3f007f04a11106a001c66bca77338d0fc375766189fd7ca3a1e8c3700"
+checksum = "1f40d362a6c146ec6dc69208f539b92fd86e47b0dbc2083801423034a38155a2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -1101,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39d9943fe71decea1e8b6a99480cefa33799ab08b5abfccd7e2a18fb07121c1"
+checksum = "22b7eafb5d85be59cbd9da83f662cf47d834f1b836e14f675d1530b12c666867"
 dependencies = [
  "anyhow",
  "borsh",
@@ -1129,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaa10feba15828c788837ddde84b994393936d8f5715228627cfe8625122a40"
+checksum = "4db893788c416287e2e1a87e6b8f5302511a04a45329e699d6a32a16874fd24f"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/bin/panic/risc0/Cargo.toml
+++ b/bin/panic/risc0/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }

--- a/bin/panic/sp1/Cargo.lock
+++ b/bin/panic/sp1/Cargo.lock
@@ -314,20 +314,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ere-platform-sp1"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "ere-platform-trait",
- "sp1-zkvm",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+name = "ere-platform-sp1"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "digest",
+ "ere-platform-core",
+ "sp1-zkvm",
 ]
 
 [[package]]

--- a/bin/panic/sp1/Cargo.toml
+++ b/bin/panic/sp1/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }

--- a/bin/panic/zisk/Cargo.lock
+++ b/bin/panic/zisk/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "clang-sys"
@@ -755,19 +755,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "fnv",
  "ziskos",
 ]
@@ -1014,12 +1011,12 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 [[package]]
 name = "lib-c"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "lib-float"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "libc"
@@ -1358,7 +1355,7 @@ dependencies = [
 [[package]]
 name = "precompiles-helpers"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -1734,7 +1731,7 @@ dependencies = [
 [[package]]
 name = "riscv"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "rustc-hash"
@@ -2924,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "zisk-common"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2949,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "zisk-core"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "elf",
  "fields",
@@ -2969,12 +2966,12 @@ dependencies = [
 [[package]]
 name = "zisk-definitions"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "zisk-verifier"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "proofman-verifier",
 ]
@@ -2982,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "ziskos"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3012,7 +3009,7 @@ dependencies = [
 [[package]]
 name = "ziskos-hints"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "anyhow",
  "bincode",

--- a/bin/panic/zisk/Cargo.toml
+++ b/bin/panic/zisk/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -918,29 +918,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "rkyv",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "risc0-zkvm",
  "risc0-zkvm-platform",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
 ]
 
 [[package]]
@@ -1265,8 +1259,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -2158,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-binfmt"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dca096030bb4c52f99b12abcfe3531ea93b17b95a12a5aeb06fbf8ee588a275"
+checksum = "1883f0c5d19b865f395209a137dcb29e56dc49951424967b8d0114c129f46e77"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2180,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "4.0.3"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1d23ef3648bb85b0bd37bc9f9f7d13f1a4388e5e779e18f7eea82b969e5dbc"
+checksum = "5f543c60287fece797a5da4209384ab1bfebd9644fcfe591e11b1aa85f1a02f8"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2196,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028cd26e1b1f7bdd964d2f1eac8f812d1872b6b8fd24f10804f07d916b90000e"
+checksum = "2347e909c6b2a65584b5898f3802eec5b8c1b4b45329edfdd8587b6a04dd3357"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -2211,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "4.0.3"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ecd73a71ddce62eab8a28552ee182dc2ea08cdce2a3474a616a80bf2d6e9be"
+checksum = "61676419814a818fdb5e10066b13c5488b3f54aa9668794bd06c99bc91bff1f2"
 dependencies = [
  "anyhow",
  "bit-vec",
@@ -2229,9 +2223,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-core"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f2723fedace48c6c5a505bd8f97ac4e1712bc4cb769083e10536d862b66987"
+checksum = "b5b956a976b8ce4713694dcc6c370b522a42ccef4ba45da5b6e57dbf26cdb7b1"
 dependencies = [
  "bytemuck",
  "rand_core 0.9.3",
@@ -2239,9 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ff13f9b427254c5264e01aaa32e33f355525299b6829449295905778f3b1e8"
+checksum = "dc57e76bb87193d154ac5ee6ee352fbd7edabddab36f02a81f40a048e5ca14f9"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -2260,9 +2254,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkos-v1compat"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf1f35f2ef61d8d86fdd06288c11d2f3bbf08f1af66b24ca0a1976ecbf324a1"
+checksum = "8bd70cb45b5d37d025f25663b87c6b9dc9df7f413ee2068531a57f50b0eb95db"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -2271,9 +2265,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb493b3f007f04a11106a001c66bca77338d0fc375766189fd7ca3a1e8c3700"
+checksum = "1f40d362a6c146ec6dc69208f539b92fd86e47b0dbc2083801423034a38155a2"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2296,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "3.0.4"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39d9943fe71decea1e8b6a99480cefa33799ab08b5abfccd7e2a18fb07121c1"
+checksum = "22b7eafb5d85be59cbd9da83f662cf47d834f1b836e14f675d1530b12c666867"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2324,9 +2318,9 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfaa10feba15828c788837ddde84b994393936d8f5715228627cfe8625122a40"
+checksum = "4db893788c416287e2e1a87e6b8f5302511a04a45329e699d6a32a16874fd24f"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -2664,6 +2658,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -2680,7 +2676,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ere-io",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-guest-program",

--- a/bin/stateless-validator-ethrex/risc0/Cargo.toml
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 c-kzg = { version = "2.1.1", features = ["eip-7594"] }
 
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
     "unstable",
     "getrandom",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -860,28 +860,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "rkyv",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "sp1-zkvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
 ]
 
 [[package]]
@@ -1310,8 +1304,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -2798,6 +2792,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -2814,7 +2810,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ere-io",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-guest-program",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.toml
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -362,11 +362,6 @@ version = "0.16.1"
 source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
-name = "circuit"
-version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
-
-[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,29 +686,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "rkyv",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "fnv",
- "ziskos 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
+ "ziskos",
 ]
 
 [[package]]
@@ -812,7 +801,7 @@ dependencies = [
  "serde_with",
  "substrate-bn",
  "thiserror",
- "ziskos 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
+ "ziskos",
 ]
 
 [[package]]
@@ -1002,8 +991,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -1260,11 +1249,6 @@ dependencies = [
 name = "lib-c"
 version = "0.16.1"
 source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
-
-[[package]]
-name = "lib-c"
-version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
 
 [[package]]
 name = "libc"
@@ -1578,26 +1562,8 @@ dependencies = [
  "ark-secp256r1",
  "ark-std",
  "cfg-if",
- "circuit 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
- "lib-c 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
- "num-bigint",
- "num-traits",
-]
-
-[[package]]
-name = "precompiles-helpers"
-version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
-dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ff",
- "ark-secp256k1",
- "ark-secp256r1",
- "ark-std",
- "cfg-if",
- "circuit 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
- "lib-c 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
+ "circuit",
+ "lib-c",
  "num-bigint",
  "num-traits",
 ]
@@ -2063,6 +2029,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -2079,7 +2047,6 @@ version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
- "ere-io",
  "ethrex-common",
  "ethrex-crypto",
  "ethrex-guest-program",
@@ -2681,22 +2648,9 @@ version = "0.16.1"
 source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
-name = "zisk-definitions"
-version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
-
-[[package]]
 name = "zisk-verifier"
 version = "0.16.1"
 source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
-dependencies = [
- "proofman-verifier",
-]
-
-[[package]]
-name = "zisk-verifier"
-version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
 dependencies = [
  "proofman-verifier",
 ]
@@ -2711,38 +2665,15 @@ dependencies = [
  "fields",
  "getrandom",
  "lazy_static",
- "lib-c 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
+ "lib-c",
  "num-bigint",
  "num-integer",
  "num-traits",
- "precompiles-helpers 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
+ "precompiles-helpers",
  "rand",
  "serde",
  "sha2",
  "tiny-keccak",
- "zisk-definitions 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
- "zisk-verifier 0.16.1 (git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1)",
-]
-
-[[package]]
-name = "ziskos"
-version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
-dependencies = [
- "bincode",
- "cfg-if",
- "fields",
- "getrandom",
- "lazy_static",
- "lib-c 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
- "num-bigint",
- "num-integer",
- "num-traits",
- "precompiles-helpers 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
- "rand",
- "serde",
- "sha2",
- "tiny-keccak",
- "zisk-definitions 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
- "zisk-verifier 0.16.1 (git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1)",
+ "zisk-definitions",
+ "zisk-verifier",
 ]

--- a/bin/stateless-validator-ethrex/zisk/Cargo.toml
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", default-features = false, features = ["inputcpy"] }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", default-features = false, features = ["inputcpy"] }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-reth/airbender/Cargo.lock
+++ b/bin/stateless-validator-reth/airbender/Cargo.lock
@@ -1300,30 +1300,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "riscv_common",
 ]
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "errno"
@@ -1535,8 +1528,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -3530,6 +3523,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -3550,7 +3545,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "ere-io",
+ "bincode",
  "guest",
  "once_cell",
  "reth-chainspec",

--- a/bin/stateless-validator-reth/airbender/Cargo.toml
+++ b/bin/stateless-validator-reth/airbender/Cargo.toml
@@ -14,7 +14,7 @@ alloy-primitives = { version = "1.5.0", default-features = false, features = [
 revm = { version = "34.0.0", default-features = false, features = ["bn"] }
 
 # ere
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "custom_allocator",
 ] }
 

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1355,29 +1355,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "openvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1591,8 +1584,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -4021,6 +4014,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -4041,7 +4036,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "ere-io",
+ "bincode",
  "guest",
  "once_cell",
  "reth-chainspec",

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -38,7 +38,7 @@ openvm-keccak256 = { git = "https://github.com/openvm-org/openvm.git", tag = "v1
 aurora-engine-modexp = { version = "1.2.0", default-features = false }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-reth/risc0/Cargo.lock
+++ b/bin/stateless-validator-reth/risc0/Cargo.lock
@@ -1486,30 +1486,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "risc0-zkvm",
  "risc0-zkvm-platform",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1749,8 +1742,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -4068,6 +4061,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -4088,7 +4083,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "ere-io",
+ "bincode",
  "guest",
  "once_cell",
  "reth-chainspec",

--- a/bin/stateless-validator-reth/risc0/Cargo.toml
+++ b/bin/stateless-validator-reth/risc0/Cargo.toml
@@ -19,7 +19,7 @@ revm = { version = "34.0.0", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", features = [
     "std",
     "unstable",
     "getrandom",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1455,29 +1455,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode 2.0.1",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
+
+[[package]]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "sp1-zkvm",
-]
-
-[[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
 ]
 
 [[package]]
@@ -1802,8 +1795,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -4282,6 +4275,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -4302,7 +4297,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "ere-io",
+ "bincode 2.0.1",
  "guest",
  "once_cell",
  "reth-chainspec",

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -17,7 +17,7 @@ revm = { version = "34.0.0", default-features = false, features = ["bn"] }
 kzg-rs = "0.2.8"
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.6.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.8.0" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth" }

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -980,7 +980,7 @@ dependencies = [
 [[package]]
 name = "circuit"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "colored"
@@ -1370,28 +1370,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "ere-io"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "bincode 2.0.1",
- "serde",
-]
+name = "ere-codec"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
-name = "ere-platform-trait"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
-dependencies = [
- "digest 0.10.7",
-]
+name = "ere-platform-core"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.6.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.6.0#12d266ed44845bf092798fc70c08e69294ef8e7d"
+version = "0.8.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.8.0#54b00745fa5fabe008b037f61f6864305c41af80"
 dependencies = [
- "ere-platform-trait",
+ "ere-platform-core",
  "fnv",
  "ziskos",
 ]
@@ -1617,8 +1610,8 @@ dependencies = [
 name = "guest"
 version = "0.8.0"
 dependencies = [
- "ere-io",
- "ere-platform-trait",
+ "ere-codec",
+ "ere-platform-core",
  "sha2",
 ]
 
@@ -1976,7 +1969,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lib-c"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "libc"
@@ -2459,7 +2452,7 @@ dependencies = [
 [[package]]
 name = "precompiles-helpers"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3703,6 +3696,8 @@ name = "stateless-validator-common"
 version = "0.8.0"
 dependencies = [
  "anyhow",
+ "ere-codec",
+ "ere-platform-core",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -3723,7 +3718,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-engine",
  "anyhow",
- "ere-io",
+ "bincode 2.0.1",
  "guest",
  "once_cell",
  "reth-chainspec",
@@ -4655,12 +4650,12 @@ dependencies = [
 [[package]]
 name = "zisk-definitions"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 
 [[package]]
 name = "zisk-verifier"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "proofman-verifier",
 ]
@@ -4668,7 +4663,7 @@ dependencies = [
 [[package]]
 name = "ziskos"
 version = "0.16.1"
-source = "git+https://github.com/han0110/zisk.git?branch=patch%2Fv0.16.1#48bba0e327f9de7360ec58583e561bfbe12b3632"
+source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v0.16.1#48cf7ccefb5ed62261abf6bfb007b5be8a23c547"
 dependencies = [
  "bincode 1.3.3",
  "cfg-if",

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -20,7 +20,7 @@ revm = { version = "34.0.0", default-features = false, features = ["bn"] }
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.6.0", default-features = false, features = ["inputcpy"] }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.8.0", default-features = false, features = ["inputcpy"] }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", features = ["zisk"] }

--- a/crates/block-encoding-length/Cargo.toml
+++ b/crates/block-encoding-length/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
+bincode = { workspace = true, features = ["alloc", "serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
 
@@ -27,8 +28,7 @@ libssz.workspace = true
 libssz_derive.workspace = true
 
 # ere
-ere-io = { workspace = true, features = ["bincode"] }
-ere-zkvm-interface = { workspace = true, optional = true }
+ere-prover-core = { workspace = true, optional = true }
 
 # local
 guest.workspace = true
@@ -42,4 +42,4 @@ default = ["std"]
 std = []
 
 # host
-host = ["std", "dep:anyhow", "dep:ere-zkvm-interface"]
+host = ["std", "dep:anyhow", "dep:ere-prover-core"]

--- a/crates/block-encoding-length/src/guest.rs
+++ b/crates/block-encoding-length/src/guest.rs
@@ -1,8 +1,9 @@
 //! [`Guest`] implementation for the block encoding length calculation.
 
+use alloc::vec::Vec;
 use core::ops::Deref;
 
-use ere_io::serde::{IoSerde, bincode::BincodeLegacy};
+use guest::codec::impl_codec_by_bincode_legacy;
 use libssz::SszEncode;
 use reth_ethereum_primitives::Block;
 use serde::{Deserialize, Serialize};
@@ -52,14 +53,17 @@ pub struct BlockEncodingLengthInput {
     pub format: BlockEncodingFormat,
 }
 
+impl_codec_by_bincode_legacy!(BlockEncodingLengthInput);
+
 /// [`Guest`] implementation for the block encoding length calculation.
 #[derive(Debug, Clone)]
 pub struct BlockEncodingLengthGuest;
 
 impl Guest for BlockEncodingLengthGuest {
-    type Io = IoSerde<BlockEncodingLengthInput, (), BincodeLegacy>;
+    type Input = BlockEncodingLengthInput;
+    type Output = ();
 
-    fn compute<P: Platform>(input: GuestInput<Self>) -> GuestOutput<Self> {
+    fn compute<P: Platform>(input: Self::Input) -> Self::Output {
         match input.format {
             BlockEncodingFormat::Rlp => {
                 P::cycle_scope("block_encoding_length_calculation", || {

--- a/crates/block-encoding-length/src/host.rs
+++ b/crates/block-encoding-length/src/host.rs
@@ -1,12 +1,9 @@
 //! Implementations for host environment.
 
-use ere_zkvm_interface::Input;
-use guest::{GuestIo, Io};
+use ere_prover_core::{Input, codec::Encode};
 use reth_ethereum_primitives::Block;
 
-use crate::guest::{
-    BincodeBlock, BlockEncodingFormat, BlockEncodingLengthGuest, BlockEncodingLengthInput,
-};
+use crate::guest::{BincodeBlock, BlockEncodingFormat, BlockEncodingLengthInput};
 
 impl BlockEncodingLengthInput {
     /// Construct [`BlockEncodingLengthInput`] given block, loop count and the
@@ -23,11 +20,10 @@ impl BlockEncodingLengthInput {
         })
     }
 
-    /// Returns [`Input`] to [`zkVM`] methods.
+    /// Returns [`Input`] to [`zkVMProver`] methods.
     ///
-    /// [`zkVM`]: ere_zkvm_interface::zkVM
+    /// [`zkVMProver`]: ere_prover_core::zkVMProver
     pub fn to_zkvm_input(&self) -> anyhow::Result<Input> {
-        let stdin = GuestIo::<BlockEncodingLengthGuest>::serialize_input(self)?;
-        Ok(Input::new().with_prefixed_stdin(stdin))
+        Ok(Input::new().with_prefixed_stdin(self.encode_to_vec()?))
     }
 }

--- a/crates/downloader/src/lib.rs
+++ b/crates/downloader/src/lib.rs
@@ -14,11 +14,9 @@ use tokio::{fs, process::Command};
 const REPO_API_URL: &str = "https://api.github.com/repos/eth-act/ere-guests";
 const ACTION_NAME: &str = "Compile and Release Compiled Guests";
 
-/// Compiled guest with serialized program and ELF.
+/// Compiled guest ELF.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompiledGuest {
-    /// Serialized `Program` defined by each zkVM.
-    pub program: Vec<u8>,
     /// Raw ELF bytes.
     pub elf: Vec<u8>,
 }
@@ -76,17 +74,13 @@ impl Downloader {
         assets: &BTreeMap<String, String>,
         guest_name: &str,
     ) -> anyhow::Result<CompiledGuest> {
-        let program_url = assets
-            .get(guest_name)
-            .with_context(|| format!("Program not found: {guest_name}"))?;
         let elf_url = assets
             .get(&format!("{guest_name}.elf"))
             .with_context(|| format!("ELF not found: {guest_name}.elf"))?;
 
-        let program = get_bytes(&self.client, program_url).await?;
         let elf = get_bytes(&self.client, elf_url).await?;
 
-        Ok(CompiledGuest { program, elf })
+        Ok(CompiledGuest { elf })
     }
 
     async fn download_from_action(
@@ -114,14 +108,11 @@ impl Downloader {
             .context("Failed to run unzip")?;
         ensure!(output.status.success(), "Unzip exited with non-zero status");
 
-        let program = fs::read(tempdir.path().join(guest_name))
-            .await
-            .with_context(|| format!("Failed to read program: {guest_name}"))?;
         let elf = fs::read(tempdir.path().join(format!("{guest_name}.elf")))
             .await
             .with_context(|| format!("Failed to read ELF: {guest_name}.elf"))?;
 
-        Ok(CompiledGuest { program, elf })
+        Ok(CompiledGuest { elf })
     }
 }
 
@@ -265,7 +256,7 @@ mod tests {
             .await?
             .download("empty-zisk")
             .await?;
-        assert!(!guest.program.is_empty() && !guest.elf.is_empty());
+        assert!(!guest.elf.is_empty());
         Ok(())
     }
 
@@ -279,7 +270,7 @@ mod tests {
             .await?
             .download("empty-zisk")
             .await?;
-        assert!(!guest.program.is_empty() && !guest.elf.is_empty());
+        assert!(!guest.elf.is_empty());
         Ok(())
     }
 }

--- a/crates/guest/Cargo.toml
+++ b/crates/guest/Cargo.toml
@@ -11,5 +11,5 @@ workspace = true
 [dependencies]
 sha2.workspace = true
 
-ere-io.workspace = true
-ere-platform-trait.workspace = true
+ere-platform-core.workspace = true
+ere-codec.workspace = true

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -4,27 +4,30 @@
 use alloc::vec::Vec;
 use core::convert::identity;
 
-use ere_io::Io;
-use ere_platform_trait::Platform;
+use ere_codec::{Decode, Encode};
+use ere_platform_core::Platform;
 use sha2::{Digest, Sha256};
 
 /// Guest program that can be ran given [`Platform`] implementation.
 pub trait Guest {
-    /// The I/O type that defines input and output serialization for this guest program.
-    type Io: Io;
+    /// Input type read from the host, deserialized via [`Decode`].
+    type Input: Encode + Decode;
+
+    /// Output type written to the host, serialized via [`Encode`].
+    type Output: Encode + Decode;
 
     /// Executes the core computation logic of the guest program.
     ///
     /// This method takes the deserialized input and produces the output for the guest program.
     /// It is called by [`Guest::run`] after reading and deserializing the input.
-    fn compute<P: Platform>(input: GuestInput<Self>) -> GuestOutput<Self>;
+    fn compute<P: Platform>(input: Self::Input) -> Self::Output;
 
     /// Runs the complete guest program workflow: reads input, computes output, and writes output.
     ///
     /// This is the main entry point for executing a guest program. It:
-    /// 1. Reads the input with the platform and deserializes it using [`Io::deserialize_input`]
+    /// 1. Reads the input with the platform and decodes it via [`Decode::decode_from_slice`]
     /// 2. Calls [`Guest::compute`] to process the input
-    /// 3. Serializes the output using [`Io::serialize_output`] and writes it with the platform
+    /// 3. Encodes the output via [`Encode::encode_to_vec`] and writes it with the platform
     fn run<P: Platform>()
     where
         Self: Sized,
@@ -48,14 +51,12 @@ fn run_inner<G: Guest, P: Platform, T: AsRef<[u8]>>(output_bytes_modifier: impl 
     let input_bytes = P::cycle_scope("read_input", || P::read_whole_input());
 
     let input = P::cycle_scope("deserialize_input", || {
-        G::Io::deserialize_input(&input_bytes).unwrap()
+        G::Input::decode_from_slice(&input_bytes).unwrap()
     });
 
     let output = G::compute::<P>(input);
 
-    let output_bytes = P::cycle_scope("serialize_output", || {
-        G::Io::serialize_output(&output).unwrap()
-    });
+    let output_bytes = P::cycle_scope("serialize_output", || output.encode_to_vec().unwrap());
 
     let modified_output_bytes = output_bytes_modifier(output_bytes);
 
@@ -64,11 +65,8 @@ fn run_inner<G: Guest, P: Platform, T: AsRef<[u8]>>(output_bytes_modifier: impl 
     });
 }
 
-/// Associated type `Io` of [`Guest`].
-pub type GuestIo<G> = <G as Guest>::Io;
+/// Associated type `Input` of [`Guest`].
+pub type GuestInput<G> = <G as Guest>::Input;
 
-/// Associated type `Input` of [`Guest::Io`].
-pub type GuestInput<G> = <GuestIo<G> as Io>::Input;
-
-/// Associated type `Output` of [`Guest::Io`].
-pub type GuestOutput<G> = <GuestIo<G> as Io>::Output;
+/// Associated type `Output` of [`Guest`].
+pub type GuestOutput<G> = <G as Guest>::Output;

--- a/crates/guest/src/lib.rs
+++ b/crates/guest/src/lib.rs
@@ -6,6 +6,6 @@ extern crate alloc;
 
 mod guest;
 
-pub use ere_io::Io;
-pub use ere_platform_trait::Platform;
-pub use guest::{Guest, GuestInput, GuestIo, GuestOutput};
+pub use ere_codec as codec;
+pub use ere_platform_core::Platform;
+pub use guest::{Guest, GuestInput, GuestOutput};

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -27,8 +27,6 @@ alloy-primitives.workspace = true
 
 # ere
 ere-dockerized.workspace = true
-ere-io.workspace = true
-ere-zkvm-interface.workspace = true
 
 # local
 guest.workspace = true
@@ -40,7 +38,6 @@ stateless.workspace = true
 reth-evm-ethereum.workspace = true
 
 # ere
-ere-zkvm-interface.workspace = true
 ere-dockerized.workspace = true
 
 # local

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -5,9 +5,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use ere_dockerized::{CompilerKind, DockerizedCompiler, DockerizedzkVM, zkVMKind};
-use ere_io::Io;
-use ere_zkvm_interface::{Compiler, Input, ProverResource, zkVM};
+use ere_dockerized::{
+    Compiler, CompilerKind, DockerizedCompiler, DockerizedzkVM, DockerizedzkVMConfig, Input,
+    ProverResource, codec::Encode, zkVMKind,
+};
 use flate2::read::GzDecoder;
 use guest::{Guest, GuestInput, GuestOutput, Platform};
 use rayon::prelude::*;
@@ -74,7 +75,13 @@ pub fn compile_and_init_zkvm(guest: &str, zkvm_kind: zkVMKind) -> DockerizedzkVM
     let bin = workspace.join("bin").join(guest).join(zkvm_kind.as_str());
     let program = compiler.compile(&bin).unwrap();
 
-    DockerizedzkVM::new(zkvm_kind, program, ProverResource::Cpu).unwrap()
+    DockerizedzkVM::new(
+        zkvm_kind,
+        program,
+        ProverResource::Cpu,
+        DockerizedzkVMConfig::default(),
+    )
+    .unwrap()
 }
 
 /// Compiles guest program and runs execution, then check output are expected.
@@ -116,7 +123,7 @@ pub fn test_execution(
         }
 
         assert_eq!(
-            public_values, expected_public_values,
+            public_values.0, expected_public_values,
             "Expected public values of test case {} to be \
                 {expected_public_values:?}, but got {public_values:?}",
             test_case.name
@@ -144,8 +151,8 @@ impl TestCase {
     ) -> Self {
         Self {
             name: name.as_ref().to_string(),
-            input: Input::new().with_prefixed_stdin(G::Io::serialize_input(&input).unwrap()),
-            expected_public_values: G::Io::serialize_output(&output).unwrap(),
+            input: Input::new().with_prefixed_stdin(input.encode_to_vec().unwrap()),
+            expected_public_values: output.encode_to_vec().unwrap(),
         }
     }
 

--- a/crates/integration-tests/src/stateless_validator.rs
+++ b/crates/integration-tests/src/stateless_validator.rs
@@ -18,8 +18,8 @@ pub struct StatelessValidatorFixture {
     pub success: bool,
 }
 
-/// Returns the expected `StatelessValidatorOutput` for a given block hash in the fixtures, which was
-/// calculated by an independent implementation.
+/// Returns the expected `StatelessValidatorOutput` for a given block hash in the fixtures, which
+/// was calculated by an independent implementation.
 pub fn get_stateless_validator_output(block_hash: B256, success: bool) -> StatelessValidatorOutput {
     let expected_roots = expected_execution_payload_tree_roots();
     let expected_root = *expected_roots.get(&block_hash).unwrap();

--- a/crates/integration-tests/tests/panic.rs
+++ b/crates/integration-tests/tests/panic.rs
@@ -1,7 +1,6 @@
 //! Execution tests for `panic` guest program
 
-use ere_dockerized::zkVMKind;
-use ere_zkvm_interface::{Input, zkVM};
+use ere_dockerized::{Input, zkVMKind};
 use integration_tests::compile_and_init_zkvm;
 
 fn test_execution(zkvm_kind: zkVMKind) {

--- a/crates/integration-tests/tests/stateless-validator-ethrex.rs
+++ b/crates/integration-tests/tests/stateless-validator-ethrex.rs
@@ -21,8 +21,9 @@ fn test_execution(zkvm_kind: zkVMKind) {
             // need to execute the block successfully first.
             StatelessValidatorRethGuest::compute::<NoopPlatform>(input.clone())
         } else {
-            // For valid blocks (i.e. mainnet), we can rely on testing the output against an independent
-            // implementation that calculated the NewPayloadRequest root from a CL block.
+            // For valid blocks (i.e. mainnet), we can rely on testing the output against an
+            // independent implementation that calculated the NewPayloadRequest root
+            // from a CL block.
             get_stateless_validator_output(
                 fixture.stateless_input.block.hash_slow(),
                 fixture.success,

--- a/crates/integration-tests/tests/stateless-validator-reth.rs
+++ b/crates/integration-tests/tests/stateless-validator-reth.rs
@@ -19,8 +19,9 @@ fn test_execution(zkvm_kind: zkVMKind) {
             // need to execute the block successfully first.
             StatelessValidatorRethGuest::compute::<NoopPlatform>(input.clone())
         } else {
-            // For valid blocks (i.e. mainnet), we can rely on testing the output against an independent
-            // implementation that calculated the NewPayloadRequest root from a CL block.
+            // For valid blocks (i.e. mainnet), we can rely on testing the output against an
+            // independent implementation that calculated the NewPayloadRequest root
+            // from a CL block.
             get_stateless_validator_output(
                 fixture.stateless_input.block.hash_slow(),
                 fixture.success,

--- a/crates/stateless-validator-common/Cargo.toml
+++ b/crates/stateless-validator-common/Cargo.toml
@@ -30,6 +30,10 @@ alloy-eips = { workspace = true, optional = true }
 # crypto
 sha2.workspace = true
 
+# ere
+ere-platform-core.workspace = true
+ere-codec.workspace = true
+
 [features]
 # guest
 default = ["std"]

--- a/crates/stateless-validator-common/src/guest.rs
+++ b/crates/stateless-validator-common/src/guest.rs
@@ -1,5 +1,13 @@
 //! Stateless validator common types and utilities for guest.
 
+use alloc::vec::Vec;
+use core::{
+    error::Error,
+    fmt::{self, Display},
+};
+
+use ere_codec::{Decode, Encode};
+
 /// Static size of [`StatelessValidatorOutput`].
 pub const STATELESS_VALIDATOR_OUTPUT_SIZE: usize = size_of::<StatelessValidatorOutput>();
 
@@ -32,5 +40,65 @@ impl StatelessValidatorOutput {
         buf[0..32].copy_from_slice(&self.new_payload_request_root);
         buf[32] = self.successful_block_validation as u8;
         buf
+    }
+}
+
+impl Encode for StatelessValidatorOutput {
+    type Error = core::convert::Infallible;
+
+    fn encode_to_vec(&self) -> Result<Vec<u8>, Self::Error> {
+        Ok(self.serialize().to_vec())
+    }
+}
+
+/// Error returned when decoding a [`StatelessValidatorOutput`] fails.
+#[derive(Debug)]
+pub enum StatelessValidatorOutputDecodeError {
+    /// Buffer is smaller than [`STATELESS_VALIDATOR_OUTPUT_SIZE`].
+    InvalidLength {
+        /// Actual length of the provided buffer.
+        len: usize,
+    },
+    /// Byte at index 32 (successful-validation flag) is not `0` or `1`.
+    InvalidSuccessulBit {
+        /// The offending byte value.
+        byte: u8,
+    },
+}
+
+impl Display for StatelessValidatorOutputDecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidLength { len } => write!(
+                f,
+                "buffer length {len} smaller than STATELESS_VALIDATOR_OUTPUT_SIZE",
+            ),
+            Self::InvalidSuccessulBit { byte } => {
+                write!(f, "successful-validation byte {byte} is not 0 or 1")
+            }
+        }
+    }
+}
+
+impl Error for StatelessValidatorOutputDecodeError {}
+
+impl Decode for StatelessValidatorOutput {
+    type Error = StatelessValidatorOutputDecodeError;
+
+    fn decode_from_slice(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() < STATELESS_VALIDATOR_OUTPUT_SIZE {
+            return Err(StatelessValidatorOutputDecodeError::InvalidLength { len: slice.len() });
+        }
+        let successful_block_validation = match slice[32] {
+            0 => false,
+            1 => true,
+            byte => {
+                return Err(StatelessValidatorOutputDecodeError::InvalidSuccessulBit { byte });
+            }
+        };
+        Ok(Self {
+            new_payload_request_root: slice[..32].try_into().unwrap(),
+            successful_block_validation,
+        })
     }
 }

--- a/crates/stateless-validator-ethrex/Cargo.toml
+++ b/crates/stateless-validator-ethrex/Cargo.toml
@@ -34,8 +34,7 @@ libssz_merkle.workspace = true
 stateless = { workspace = true, optional = true }
 
 # ere
-ere-io = { workspace = true, features = ["rkyv"] }
-ere-zkvm-interface = { workspace = true, optional = true }
+ere-prover-core = { workspace = true, optional = true }
 
 # local
 guest.workspace = true
@@ -63,7 +62,7 @@ host = [
     "dep:alloy-eips",
     "dep:alloy-rlp",
     "dep:alloy-genesis",
-    "dep:ere-zkvm-interface",
+    "dep:ere-prover-core",
     "dep:ethrex-rpc",
     "dep:stateless",
     "dep:stateless-validator-reth",

--- a/crates/stateless-validator-ethrex/src/execution_payload.rs
+++ b/crates/stateless-validator-ethrex/src/execution_payload.rs
@@ -39,7 +39,8 @@ pub struct EncodedTransaction(pub Bytes);
 
 impl ExecutionPayload {
     /// Converts an `ExecutionPayload` into a block (aka a BlockHeader and BlockBody)
-    /// using the parentBeaconBlockRoot received along with the payload in the rpc call `engine_newPayloadV2/V3`
+    /// using the parentBeaconBlockRoot received along with the payload in the rpc call
+    /// `engine_newPayloadV2/V3`
     pub fn into_block(
         self,
         parent_beacon_block_root: Option<H256>,

--- a/crates/stateless-validator-ethrex/src/guest.rs
+++ b/crates/stateless-validator-ethrex/src/guest.rs
@@ -15,7 +15,7 @@ use crate::new_payload_request::get_block_from_new_payload_request;
 #[rustfmt::skip]
 pub use {
     guest::*,
-    stateless_validator_common::guest::StatelessValidatorOutput,
+    stateless_validator_common::{guest::StatelessValidatorOutput, new_payload_request},
 };
 
 /// Input for the Ethrex stateless validator guest program.

--- a/crates/stateless-validator-ethrex/src/guest.rs
+++ b/crates/stateless-validator-ethrex/src/guest.rs
@@ -3,10 +3,10 @@
 use alloc::{format, sync::Arc};
 use core::fmt::Debug;
 
-use ere_io::rkyv::IoRkyv;
 use ethrex_common::types::block_execution_witness::ExecutionWitness;
 use ethrex_crypto::Crypto;
 use ethrex_guest_program::{execution::execution_program, input::ProgramInput};
+use guest::codec::impl_codec_by_rkyv;
 use libssz_merkle::Sha256Hasher;
 use stateless_validator_common::new_payload_request::NewPayloadRequest;
 
@@ -63,9 +63,7 @@ impl Debug for StatelessValidatorEthrexInput {
     }
 }
 
-/// [`Io`] implementation of Ethrex stateless validator.
-pub type StatelessValidatorEthrexIo =
-    IoRkyv<StatelessValidatorEthrexInput, StatelessValidatorOutput>;
+impl_codec_by_rkyv!(StatelessValidatorEthrexInput);
 
 /// [`Guest`] implementation for Ethrex stateless validator.
 #[derive(Debug, Clone)]
@@ -88,9 +86,10 @@ impl Sha256Hasher for EthrexSha256Hasher<'_> {
 }
 
 impl Guest for StatelessValidatorEthrexGuest {
-    type Io = StatelessValidatorEthrexIo;
+    type Input = StatelessValidatorEthrexInput;
+    type Output = StatelessValidatorOutput;
 
-    fn compute<P: Platform>(input: GuestInput<Self>) -> GuestOutput<Self> {
+    fn compute<P: Platform>(input: Self::Input) -> Self::Output {
         let crypto = crypto();
         let new_payload_request_root =
             P::cycle_scope("new_payload_request_root_calculation", || {
@@ -169,47 +168,4 @@ fn crypto() -> Arc<dyn Crypto> {
     return Arc::new(ethrex_guest_program::crypto::zisk::ZiskCrypto);
     #[cfg(not(any(feature = "risc0", feature = "sp1", feature = "zisk")))]
     return Arc::new(ethrex_guest_program::crypto::NativeCrypto);
-}
-
-#[cfg(test)]
-mod test {
-    use stateless_validator_common::new_payload_request::{
-        ExecutionPayloadV1, NativeSha256Hasher, NewPayloadRequest, NewPayloadRequestBellatrix,
-    };
-
-    use crate::guest::{Io, StatelessValidatorEthrexIo, StatelessValidatorOutput};
-
-    #[test]
-    fn serialize_output() {
-        let dummy_new_payload_request_root =
-            NewPayloadRequest::Bellatrix(NewPayloadRequestBellatrix {
-                execution_payload: ExecutionPayloadV1 {
-                    parent_hash: [1; 32],
-                    fee_recipient: [2; 20],
-                    state_root: [3; 32],
-                    receipts_root: [4; 32],
-                    logs_bloom: [0; 256],
-                    prev_randao: [5; 32],
-                    block_number: 1,
-                    gas_limit: 2,
-                    gas_used: 3,
-                    timestamp: 4,
-                    extra_data: Default::default(),
-                    base_fee_per_gas: [6; 32],
-                    block_hash: [7; 32],
-                    transactions: Default::default(),
-                },
-            })
-            .tree_hash_root(&NativeSha256Hasher);
-
-        for output in [
-            StatelessValidatorOutput::new(dummy_new_payload_request_root, false),
-            StatelessValidatorOutput::new(dummy_new_payload_request_root, true),
-        ] {
-            assert_eq!(
-                StatelessValidatorEthrexIo::serialize_output(&output).unwrap(),
-                output.serialize()
-            );
-        }
-    }
 }

--- a/crates/stateless-validator-ethrex/src/host.rs
+++ b/crates/stateless-validator-ethrex/src/host.rs
@@ -1,7 +1,7 @@
 //! Implementations for host environment.
 
 use alloy_eips::eip6110::MAINNET_DEPOSIT_CONTRACT_ADDRESS;
-use ere_zkvm_interface::Input;
+use ere_prover_core::{Input, codec::Encode};
 use ethrex_common::{
     H160,
     types::{
@@ -9,10 +9,9 @@ use ethrex_common::{
         block_execution_witness::{self, RpcExecutionWitness},
     },
 };
-use guest::{GuestIo, Io};
 use stateless_validator_reth::guest::StatelessValidatorRethInput;
 
-use crate::guest::{StatelessValidatorEthrexGuest, StatelessValidatorEthrexInput};
+use crate::guest::StatelessValidatorEthrexInput;
 
 #[rustfmt::skip]
 pub use {
@@ -35,12 +34,11 @@ impl StatelessValidatorEthrexInput {
         })
     }
 
-    /// Returns [`Input`] to [`zkVM`] methods.
+    /// Returns [`Input`] to [`zkVMProver`] methods.
     ///
-    /// [`zkVM`]: ere_zkvm_interface::zkVM
+    /// [`zkVMProver`]: ere_prover_core::zkVMProver
     pub fn to_zkvm_input(&self) -> anyhow::Result<Input> {
-        let stdin = GuestIo::<StatelessValidatorEthrexGuest>::serialize_input(self)?;
-        Ok(Input::new().with_prefixed_stdin(stdin))
+        Ok(Input::new().with_prefixed_stdin(self.encode_to_vec()?))
     }
 }
 
@@ -153,8 +151,9 @@ fn get_blob_schedule(
         .blob_schedule
         .get(name)
         .map(|s| ForkBlobSchedule {
-            // Reth and Ethrex have some mismatched data type representations. Reth uses bigger ints.
-            // Downcasting should never cause an overflow, but let's be safe and panic if this ever happens.
+            // Reth and Ethrex have some mismatched data type representations. Reth uses bigger
+            // ints. Downcasting should never cause an overflow, but let's be safe and
+            // panic if this ever happens.
             base_fee_update_fraction: s.update_fraction.try_into().unwrap(),
             target: s.target_blob_count.try_into().unwrap(),
             max: s.max_blob_count.try_into().unwrap(),

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -36,8 +36,8 @@ stateless.workspace = true
 tries.workspace = true
 
 # ere
-ere-io = { workspace = true, features = ["bincode"] }
-ere-zkvm-interface = { workspace = true, optional = true }
+bincode = { workspace = true, features = ["alloc", "serde"] }
+ere-prover-core = { workspace = true, optional = true }
 
 # crypto
 sha2.workspace = true
@@ -54,4 +54,4 @@ openvm = []
 zisk = []
 
 # host
-host = ["std", "stateless-validator-common/host", "dep:ere-zkvm-interface"]
+host = ["std", "stateless-validator-common/host", "dep:ere-prover-core"]

--- a/crates/stateless-validator-reth/src/guest.rs
+++ b/crates/stateless-validator-reth/src/guest.rs
@@ -3,7 +3,7 @@
 use alloc::{format, sync::Arc, vec::Vec};
 
 use alloy_genesis::ChainConfig;
-use ere_io::serde::{IoSerde, bincode::BincodeLegacy};
+use guest::codec::impl_codec_by_bincode_legacy;
 use reth_chainspec::ChainSpec;
 use reth_evm_ethereum::EthEvmConfig;
 use serde::{Deserialize, Serialize};
@@ -40,18 +40,17 @@ pub struct StatelessValidatorRethInput {
     pub public_keys: Vec<UncompressedPublicKey>,
 }
 
-/// [`Io`] implementation of Reth stateless validator.
-pub type StatelessValidatorRethIo =
-    IoSerde<StatelessValidatorRethInput, StatelessValidatorOutput, BincodeLegacy>;
+impl_codec_by_bincode_legacy!(StatelessValidatorRethInput);
 
 /// [`Guest`] implementation for Reth stateless validator.
 #[derive(Debug, Clone)]
 pub struct StatelessValidatorRethGuest;
 
 impl Guest for StatelessValidatorRethGuest {
-    type Io = StatelessValidatorRethIo;
+    type Input = StatelessValidatorRethInput;
+    type Output = StatelessValidatorOutput;
 
-    fn compute<P: Platform>(input: GuestInput<Self>) -> GuestOutput<Self> {
+    fn compute<P: Platform>(input: Self::Input) -> Self::Output {
         let new_payload_request_root =
             P::cycle_scope("new_payload_request_root_calculation", || {
                 input.new_payload_request.tree_hash_root(&sha256_hasher())

--- a/crates/stateless-validator-reth/src/guest.rs
+++ b/crates/stateless-validator-reth/src/guest.rs
@@ -17,7 +17,7 @@ use crate::new_payload_request::new_payload_request_to_block;
 #[rustfmt::skip]
 pub use {
     guest::*,
-    stateless_validator_common::guest::StatelessValidatorOutput,
+    stateless_validator_common::{guest::StatelessValidatorOutput, new_payload_request},
 };
 
 #[cfg(feature = "openvm")]

--- a/crates/stateless-validator-reth/src/host.rs
+++ b/crates/stateless-validator-reth/src/host.rs
@@ -8,8 +8,7 @@ use alloy_eips::{Encodable2718, eip7685::Requests};
 use alloy_genesis::{ChainConfig, Genesis};
 use alloy_primitives::U256;
 use anyhow::Context;
-use ere_zkvm_interface::Input;
-use guest::{GuestIo, Io};
+use ere_prover_core::{Input, codec::Encode};
 use reth_chainspec::ChainSpec;
 use reth_ethereum_primitives::TransactionSigned;
 use reth_evm_ethereum::EthEvmConfig;
@@ -23,7 +22,7 @@ use stateless_validator_common::new_payload_request::{
 };
 use tries::zeth::SparseState;
 
-use crate::guest::{StatelessValidatorRethGuest, StatelessValidatorRethInput};
+use crate::guest::StatelessValidatorRethInput;
 
 impl StatelessValidatorRethInput {
     /// Construct [`StatelessValidatorRethInput`] given [`StatelessInput`].
@@ -40,12 +39,11 @@ impl StatelessValidatorRethInput {
         })
     }
 
-    /// Returns [`Input`] to [`zkVM`] methods.
+    /// Returns [`Input`] to [`zkVMProver`] methods.
     ///
-    /// [`zkVM`]: ere_zkvm_interface::zkVM
+    /// [`zkVMProver`]: ere_prover_core::zkVMProver
     pub fn to_zkvm_input(&self) -> anyhow::Result<Input> {
-        let stdin = GuestIo::<StatelessValidatorRethGuest>::serialize_input(self)?;
-        Ok(Input::new().with_prefixed_stdin(stdin))
+        Ok(Input::new().with_prefixed_stdin(self.encode_to_vec()?))
     }
 }
 
@@ -305,43 +303,4 @@ fn get_requests(
     // why isn't required and mark it as error otherwise. Since this is only used
     // in the host side, we can afford the extra clone.
     Ok(out.requests.clone())
-}
-
-#[cfg(test)]
-mod test {
-    use stateless_validator_common::new_payload_request::{
-        ExecutionPayloadV1, NativeSha256Hasher, NewPayloadRequest,
-    };
-
-    use crate::guest::{Io, StatelessValidatorOutput, StatelessValidatorRethIo};
-
-    #[test]
-    fn serialize_output() {
-        let dummy_new_payload_request_root = NewPayloadRequest::new_bellatrix(ExecutionPayloadV1 {
-            parent_hash: [1; 32],
-            fee_recipient: [2; 20],
-            state_root: [3; 32],
-            receipts_root: [4; 32],
-            logs_bloom: [0; 256],
-            prev_randao: [5; 32],
-            block_number: 1,
-            gas_limit: 2,
-            gas_used: 3,
-            timestamp: 4,
-            extra_data: Default::default(),
-            base_fee_per_gas: [6; 32],
-            block_hash: [7; 32],
-            transactions: Default::default(),
-        })
-        .tree_hash_root(&NativeSha256Hasher);
-        for output in [
-            StatelessValidatorOutput::new(dummy_new_payload_request_root, false),
-            StatelessValidatorOutput::new(dummy_new_payload_request_root, true),
-        ] {
-            assert_eq!(
-                StatelessValidatorRethIo::serialize_output(&output).unwrap(),
-                output.serialize()
-            );
-        }
-    }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,5 @@
 group_imports = "StdExternalCrate"
 imports_granularity = "Crate"
 unstable_features = true
+wrap_comments = true
+comment_width = 100


### PR DESCRIPTION
- Update `ere` to `v0.8.0` with serveral breaking changes:
  - `ere-platform-trait` is renamed to `ere-platform-core`, and the image tag extraction script is updated:
    ```
    cargo tree -p ere-platform-core \
      | head -n 1 \
      | sed -E -e 's/.*\?rev=(.{7}).*/\1/' -e 's/.*\?tag=v([0-9.]+).*/\1/'
    ```
    that extracts either revision or tag
  - `ere-io` is removed, and `Guest::Io` is replaced with `Guest::{Input,Output}: Encode + Decode` that uses `ere-codec` to implement a canonical encoding/decoding format for guest 
  - `ere-zkvm-interface` is renamed to `ere-prover-core` (also avoid confusion with the `zkvm-inferface.h` in `zkvm-standard`)input/output
- CI
  - Program is removed from the release, now `ere-server` takes raw ELF
  - Program verifying key is added in release as `{guest_name}.vk`, which can be used to initialized `zkVMVerifier`
  - Do `compile-and-release.yml` workflow dry-run (compile/keygen without publish)
  - Check duplicated crates on zkVM runtime