### PR TITLE
feat: update ere to v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,8 +2224,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-catalog"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -2234,21 +2234,21 @@ dependencies = [
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-compiler-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ere-dockerized"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -2264,13 +2264,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-prover-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -2286,8 +2286,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-api"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "prost",
  "serde",
@@ -2296,8 +2296,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-client"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -2308,24 +2308,24 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "cargo_metadata",
 ]
 
 [[package]]
 name = "ere-util-tokio"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "ere-verifier-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "auto_impl",
  "ere-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,10 +115,10 @@ libssz_types = { package = "libssz-types", version = "0.2.1", default-features =
 zkvm-interface = { git = "https://github.com/0xPolygonHermez/zisk.git", tag = "v0.18.0" }
 
 # ere
-ere-codec = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
-ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
-ere-prover-core = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-codec = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-prover-core = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
 
 # local
 guest = { path = "crates/guest", default-features = false }

--- a/bin/empty/airbender/Cargo.lock
+++ b/bin/empty/airbender/Cargo.lock
@@ -91,8 +91,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "airbender-sdk",
  "ere-platform-core",
@@ -100,8 +100,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "getrandom"

--- a/bin/empty/airbender/Cargo.toml
+++ b/bin/empty/airbender/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }

--- a/bin/empty/openvm/Cargo.lock
+++ b/bin/empty/openvm/Cargo.lock
@@ -35,13 +35,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/empty/openvm/Cargo.toml
+++ b/bin/empty/openvm/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }

--- a/bin/empty/risc0/Cargo.lock
+++ b/bin/empty/risc0/Cargo.lock
@@ -538,13 +538,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",

--- a/bin/empty/risc0/Cargo.toml
+++ b/bin/empty/risc0/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }

--- a/bin/empty/sp1/Cargo.lock
+++ b/bin/empty/sp1/Cargo.lock
@@ -322,13 +322,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",

--- a/bin/empty/sp1/Cargo.toml
+++ b/bin/empty/sp1/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }

--- a/bin/empty/zisk/Cargo.lock
+++ b/bin/empty/zisk/Cargo.lock
@@ -1331,17 +1331,16 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "ziskos",
- "zkvm-interface",
 ]
 
 [[package]]

--- a/bin/empty/zisk/Cargo.toml
+++ b/bin/empty/zisk/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
 
 [features]
 cycle-scope = ["ere-platform-zisk/cycle-scope"]

--- a/bin/panic/airbender/Cargo.lock
+++ b/bin/panic/airbender/Cargo.lock
@@ -84,8 +84,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "airbender-sdk",
  "ere-platform-core",
@@ -93,8 +93,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "getrandom"

--- a/bin/panic/airbender/Cargo.toml
+++ b/bin/panic/airbender/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }

--- a/bin/panic/openvm/Cargo.lock
+++ b/bin/panic/openvm/Cargo.lock
@@ -28,13 +28,13 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/panic/openvm/Cargo.toml
+++ b/bin/panic/openvm/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }

--- a/bin/panic/risc0/Cargo.lock
+++ b/bin/panic/risc0/Cargo.lock
@@ -531,13 +531,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",

--- a/bin/panic/risc0/Cargo.toml
+++ b/bin/panic/risc0/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }

--- a/bin/panic/sp1/Cargo.lock
+++ b/bin/panic/sp1/Cargo.lock
@@ -315,13 +315,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",

--- a/bin/panic/sp1/Cargo.toml
+++ b/bin/panic/sp1/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }

--- a/bin/panic/zisk/Cargo.lock
+++ b/bin/panic/zisk/Cargo.lock
@@ -1324,17 +1324,16 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "ziskos",
- "zkvm-interface",
 ]
 
 [[package]]

--- a/bin/panic/zisk/Cargo.toml
+++ b/bin/panic/zisk/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
 
 [features]
 cycle-scope = ["ere-platform-zisk/cycle-scope"]

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -920,18 +920,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",

--- a/bin/stateless-validator-ethrex/risc0/Cargo.toml
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 c-kzg = { version = "2.1.1", features = ["eip-7594"] }
 
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
     "unstable",
     "getrandom",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -865,18 +865,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.toml
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -766,22 +766,21 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "ziskos",
- "zkvm-interface",
 ]
 
 [[package]]

--- a/bin/stateless-validator-ethrex/zisk/Cargo.toml
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", default-features = false, features = ["inputcpy"] }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", default-features = false, features = ["inputcpy"] }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-reth/airbender/Cargo.lock
+++ b/bin/stateless-validator-reth/airbender/Cargo.lock
@@ -1135,13 +1135,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "airbender-sdk",
  "ere-platform-core",
@@ -1149,8 +1149,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "fastrand"

--- a/bin/stateless-validator-reth/airbender/Cargo.toml
+++ b/bin/stateless-validator-reth/airbender/Cargo.toml
@@ -14,7 +14,7 @@ alloy-primitives = { version = "1.5.0", default-features = false, features = [
 revm = { version = "38.0.0", default-features = false, features = ["bn"] }
 
 # ere
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -1120,18 +1120,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -38,7 +38,7 @@ openvm-keccak256 = { git = "https://github.com/openvm-org/openvm.git", tag = "v1
 aurora-engine-modexp = { version = "1.2.0", default-features = false }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-reth/risc0/Cargo.lock
+++ b/bin/stateless-validator-reth/risc0/Cargo.lock
@@ -1309,18 +1309,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",

--- a/bin/stateless-validator-reth/risc0/Cargo.toml
+++ b/bin/stateless-validator-reth/risc0/Cargo.toml
@@ -18,7 +18,7 @@ revm = { version = "38.0.0", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
     "std",
     "unstable",
     "getrandom",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -1301,18 +1301,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -17,7 +17,7 @@ revm = { version = "38.0.0", default-features = false, features = ["bn"] }
 kzg-rs = "0.2.8"
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.10.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth" }

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -1147,22 +1147,21 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.10.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.10.0#1a4068a9c402d0813e7f0f0f05f48e1605b944f8"
+version = "0.11.0"
+source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
 dependencies = [
  "ere-platform-core",
  "ziskos",
- "zkvm-interface",
 ]
 
 [[package]]

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -20,7 +20,7 @@ revm = { version = "38.0.0", default-features = false, features = ["bn"] }
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.10.0", default-features = false, features = [
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", default-features = false, features = [
     "inputcpy",
 ] }
 

--- a/bin/stateless-validator-reth/zisk/src/main.rs
+++ b/bin/stateless-validator-reth/zisk/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
 
 #[unsafe(no_mangle)]
 fn _critical_section_1_0_acquire() -> u64 {
-    return 0;
+    0
 }
 
 #[unsafe(no_mangle)]

--- a/crates/guest/src/guest.rs
+++ b/crates/guest/src/guest.rs
@@ -36,7 +36,7 @@ pub trait Guest {
     }
 
     /// Runs the complete guest program workflow but hash the output by sha256
-    /// before calling the inner `P::write_whole_output`.
+    /// before calling the inner `P::write_output`.
     fn run_output_sha256<P: Platform>()
     where
         Self: Sized,
@@ -48,7 +48,7 @@ pub trait Guest {
 }
 
 fn run_inner<G: Guest, P: Platform, T: AsRef<[u8]>>(output_bytes_modifier: impl Fn(Vec<u8>) -> T) {
-    let input_bytes = P::cycle_scope("read_input", || P::read_whole_input());
+    let input_bytes = P::cycle_scope("read_input", || P::read_input());
 
     let input = P::cycle_scope("deserialize_input", || {
         G::Input::decode_from_slice(&input_bytes).unwrap()
@@ -61,7 +61,7 @@ fn run_inner<G: Guest, P: Platform, T: AsRef<[u8]>>(output_bytes_modifier: impl 
     let modified_output_bytes = output_bytes_modifier(output_bytes);
 
     P::cycle_scope("write_output", || {
-        P::write_whole_output(modified_output_bytes.as_ref())
+        P::write_output(modified_output_bytes.as_ref())
     });
 }
 

--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -151,7 +151,7 @@ impl TestCase {
     ) -> Self {
         Self {
             name: name.as_ref().to_string(),
-            input: Input::new().with_prefixed_stdin(input.encode_to_vec().unwrap()),
+            input: Input::new().with_stdin(input.encode_to_vec().unwrap()),
             expected_public_values: output.encode_to_vec().unwrap(),
         }
     }
@@ -168,12 +168,12 @@ pub struct NoopPlatform;
 
 impl Platform for NoopPlatform {
     #[allow(unreachable_code)]
-    fn read_whole_input() -> impl std::ops::Deref<Target = [u8]> {
+    fn read_input() -> impl std::ops::Deref<Target = [u8]> {
         panic!("Can't read input in NoopPlatform");
         &[] as &[u8]
     }
 
-    fn write_whole_output(_: &[u8]) {
+    fn write_output(_: &[u8]) {
         panic!("Can't write output in NoopPlatform");
     }
 

--- a/crates/stateless-validator-debug/src/lib.rs
+++ b/crates/stateless-validator-debug/src/lib.rs
@@ -138,12 +138,12 @@ pub struct StdoutNoopPlatform;
 
 impl Platform for StdoutNoopPlatform {
     #[allow(unreachable_code)]
-    fn read_whole_input() -> impl std::ops::Deref<Target = [u8]> {
+    fn read_input() -> impl std::ops::Deref<Target = [u8]> {
         panic!("Can't read input in StdoutNoopPlatform");
         &[] as &[u8]
     }
 
-    fn write_whole_output(_: &[u8]) {
+    fn write_output(_: &[u8]) {
         panic!("Can't write output in StdoutNoopPlatform");
     }
 

--- a/crates/stateless-validator-reth/src/guest.rs
+++ b/crates/stateless-validator-reth/src/guest.rs
@@ -51,7 +51,6 @@ impl Guest for StatelessValidatorRethGuest {
     type Output = StatelessValidatorOutput;
 
     fn compute<P: Platform>(input: Self::Input) -> Self::Output {
-        let chain_id = input.chain_config.chain_id;
         let new_payload_request_root =
             P::cycle_scope("new_payload_request_root_calculation", || {
                 input.new_payload_request.tree_hash_root(&sha256_hasher())
@@ -59,6 +58,8 @@ impl Guest for StatelessValidatorRethGuest {
 
         #[cfg(feature = "std")]
         {
+            let chain_id = input.chain_config.chain_id;
+
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 Self::compute_inner::<P>(input, new_payload_request_root)
             }));

--- a/crates/stateless-validator-reth/src/host.rs
+++ b/crates/stateless-validator-reth/src/host.rs
@@ -43,7 +43,7 @@ impl StatelessValidatorRethInput {
     ///
     /// [`zkVMProver`]: ere_prover_core::zkVMProver
     pub fn to_zkvm_input(&self) -> anyhow::Result<Input> {
-        Ok(Input::new().with_prefixed_stdin(self.encode_to_vec()?))
+        Ok(Input::new().with_stdin(self.encode_to_vec()?))
     }
 }
 


### PR DESCRIPTION
- Bump ere to v0.11.0
- Update `Platform` and `Input` API, no more guest side framed stdin (the length prefix), to be compatible with `zkvm-standards`
- ZisK `cycle-scope` shows steps of profile tags (previously only costs)