### PR TITLE
Update libssz to v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
  "bitflags 2.11.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2408,10 +2408,10 @@ dependencies = [
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "lru",
  "once_cell",
  "rayon",
@@ -2464,10 +2464,10 @@ dependencies = [
  "ethrex-vm",
  "hex",
  "k256",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "rkyv",
  "serde",
  "serde_with",
@@ -3407,7 +3407,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3957,29 +3957,18 @@ dependencies = [
 [[package]]
 name = "libssz"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "libssz-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -3993,13 +3982,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssz-merkle"
-version = "0.2.1"
+name = "libssz-derive"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4007,28 +3997,38 @@ name = "libssz-merkle"
 version = "0.2.1"
 source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+dependencies = [
+ "libssz 0.2.2",
  "sha2",
 ]
 
 [[package]]
 name = "libssz-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.1",
+ "libssz-merkle 0.2.1",
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "smallvec",
 ]
 
@@ -5329,7 +5329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5448,7 +5448,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7731,10 +7731,10 @@ dependencies = [
  "anyhow",
  "ere-codec",
  "ere-platform-core",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
  "rkyv",
  "serde",
  "serde_with",
@@ -7777,8 +7777,8 @@ dependencies = [
  "ethrex-guest-program",
  "ethrex-rpc",
  "guest",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "rkyv",
  "stateless",
  "stateless-validator-common",
@@ -8913,7 +8913,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,12 +102,12 @@ ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882
 ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
 
 # ssz
-libssz = { version = "0.2.1", default-features = false, features = ["alloc"] }
-libssz_derive = { package = "libssz-derive", version = "0.2.1" }
-libssz_merkle = { package = "libssz-merkle", version = "0.2.1", default-features = false, features = [
+libssz = { version = "0.2.2", default-features = false, features = ["alloc"] }
+libssz_derive = { package = "libssz-derive", version = "0.2.2" }
+libssz_merkle = { package = "libssz-merkle", version = "0.2.2", default-features = false, features = [
     "alloc",
 ] }
-libssz_types = { package = "libssz-types", version = "0.2.1", default-features = false, features = [
+libssz_types = { package = "libssz-types", version = "0.2.2", default-features = false, features = [
     "alloc",
 ] }
 

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -1022,10 +1022,10 @@ dependencies = [
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "lru",
  "once_cell",
  "rkyv",
@@ -1074,10 +1074,10 @@ dependencies = [
  "ethrex-vm",
  "hex",
  "k256",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "rkyv",
  "serde",
  "serde_with",
@@ -1617,29 +1617,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libssz"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "libssz-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1653,13 +1642,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssz-merkle"
-version = "0.2.1"
+name = "libssz-derive"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1667,28 +1657,38 @@ name = "libssz-merkle"
 version = "0.2.1"
 source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+dependencies = [
+ "libssz 0.2.2",
  "sha2",
 ]
 
 [[package]]
 name = "libssz-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.1",
+ "libssz-merkle 0.2.1",
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "smallvec",
 ]
 
@@ -2773,10 +2773,10 @@ dependencies = [
  "anyhow",
  "ere-codec",
  "ere-platform-core",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
  "serde",
  "serde_with",
  "sha2",
@@ -2792,8 +2792,8 @@ dependencies = [
  "ethrex-crypto",
  "ethrex-guest-program",
  "guest",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "rkyv",
  "stateless-validator-common",
 ]

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -966,10 +966,10 @@ dependencies = [
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "lru",
  "once_cell",
  "rayon",
@@ -1021,10 +1021,10 @@ dependencies = [
  "ethrex-vm",
  "hex",
  "k256",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "rkyv",
  "serde",
  "serde_with",
@@ -1733,29 +1733,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libssz"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "libssz-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1769,13 +1758,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssz-merkle"
-version = "0.2.1"
+name = "libssz-derive"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1783,28 +1773,38 @@ name = "libssz-merkle"
 version = "0.2.1"
 source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+dependencies = [
+ "libssz 0.2.2",
  "sha2",
 ]
 
 [[package]]
 name = "libssz-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.1",
+ "libssz-merkle 0.2.1",
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "smallvec",
 ]
 
@@ -2901,10 +2901,10 @@ dependencies = [
  "anyhow",
  "ere-codec",
  "ere-platform-core",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
  "serde",
  "serde_with",
  "sha2",
@@ -2920,8 +2920,8 @@ dependencies = [
  "ethrex-crypto",
  "ethrex-guest-program",
  "guest",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "rkyv",
  "stateless-validator-common",
 ]

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -867,10 +867,10 @@ dependencies = [
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "lru",
  "once_cell",
  "rkyv",
@@ -916,10 +916,10 @@ dependencies = [
  "ethrex-rlp",
  "ethrex-vm",
  "hex",
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-derive 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-types 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "libssz-derive 0.2.1",
+ "libssz-merkle 0.2.1",
+ "libssz-types 0.2.1",
  "rkyv",
  "serde",
  "serde_with",
@@ -1446,29 +1446,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 [[package]]
 name = "libssz"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "libssz-derive"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1482,13 +1471,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "libssz-merkle"
-version = "0.2.1"
+name = "libssz-derive"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1496,28 +1486,38 @@ name = "libssz-merkle"
 version = "0.2.1"
 source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.1",
+ "sha2",
+]
+
+[[package]]
+name = "libssz-merkle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
+dependencies = [
+ "libssz 0.2.2",
  "sha2",
 ]
 
 [[package]]
 name = "libssz-types"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
 dependencies = [
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.1",
+ "libssz-merkle 0.2.1",
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
-source = "git+https://github.com/lambdaclass/libssz?rev=7262a4f#7262a4f17f71fb9108166ba260659bcdd64feb4c"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
- "libssz 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
- "libssz-merkle 0.2.1 (git+https://github.com/lambdaclass/libssz?rev=7262a4f)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "smallvec",
 ]
 
@@ -2402,10 +2402,10 @@ dependencies = [
  "anyhow",
  "ere-codec",
  "ere-platform-core",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-types 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-derive 0.2.2",
+ "libssz-merkle 0.2.2",
+ "libssz-types 0.2.2",
  "serde",
  "serde_with",
  "sha2",
@@ -2421,8 +2421,8 @@ dependencies = [
  "ethrex-crypto",
  "ethrex-guest-program",
  "guest",
- "libssz 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libssz-merkle 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libssz 0.2.2",
+ "libssz-merkle 0.2.2",
  "rkyv",
  "stateless-validator-common",
  "zkvm-interface",

--- a/bin/stateless-validator-reth/airbender/Cargo.lock
+++ b/bin/stateless-validator-reth/airbender/Cargo.lock
@@ -1605,18 +1605,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-derive"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1625,9 +1625,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-merkle"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
  "sha2",
@@ -1635,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
  "libssz",
  "libssz-merkle",

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -291,7 +291,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1659,18 +1659,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-derive"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1679,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-merkle"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
  "sha2",
@@ -1689,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
  "libssz",
  "libssz-merkle",

--- a/bin/stateless-validator-reth/risc0/Cargo.lock
+++ b/bin/stateless-validator-reth/risc0/Cargo.lock
@@ -1820,18 +1820,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-derive"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1840,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-merkle"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
  "sha2",
@@ -1850,9 +1850,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
  "libssz",
  "libssz-merkle",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1962,18 +1962,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-derive"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1982,9 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-merkle"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
  "sha2",
@@ -1992,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
  "libssz",
  "libssz-merkle",

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -1643,18 +1643,18 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libssz"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54193e6560611847aceb81ae53c75aa7031b50304bead95ec935f97af79378f2"
+checksum = "d498c0482bba87d2647ea4601ea76cf2b498065e3958798a88f49274f3ced5e9"
 dependencies = [
  "smallvec",
 ]
 
 [[package]]
 name = "libssz-derive"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb6393ec2e9b660bbcb0d9d74aac7b3c351c7b4440dcc24e9d344e62cf4bf10"
+checksum = "08ddfb5c969c28a4a54043e630f80c723352637bd1020f256ee3ac7a8814922b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1663,9 +1663,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-merkle"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37acd26ea2fbecfd8af8121780a385284cfb6d6f4c2f77648a9798b5d95a87d8"
+checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
  "sha2",
@@ -1673,9 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "libssz-types"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc4f9486929bd568731a599e9b4914aa44a0b4ecbd38c702151fe97210c323"
+checksum = "747273ab2d923e82ed147091fe0fb3e602dd2012c872cdad5efe69e27c3b4099"
 dependencies = [
  "libssz",
  "libssz-merkle",


### PR DESCRIPTION
Update `libssz` to v0.2.2 -- fixes a [security bug](https://github.com/lambdaclass/libssz/pull/24) I found yesterday.