### PR TITLE
feat: update ere

### DIFF
--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -39,6 +39,10 @@ jobs:
             zkvm: airbender
           - el: ethrex
             zkvm: openvm
+        include:
+          - el: ethrex
+            zkvm: zisk
+            ere_profile: ethrex
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,6 +66,7 @@ jobs:
       - name: Compile guest
         run: |
           docker run \
+            ${{ matrix.ere_profile && format('-e ERE_PROFILE={0}', matrix.ere_profile) || '' }} \
             -e OPENVM_RUST_TOOLCHAIN=nightly-2025-10-30 \
             -e RUST_LOG=info \
             -v $PWD:/ere-guests \
@@ -76,6 +81,7 @@ jobs:
         if: ${{ matrix.zkvm == 'zisk' }}
         run: |
           docker run \
+            ${{ matrix.ere_profile && format('-e ERE_PROFILE={0}', matrix.ere_profile) || '' }} \
             -e OPENVM_RUST_TOOLCHAIN=nightly-2025-10-30 \
             -e RUST_LOG=info \
             -v $PWD:/ere-guests \

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -47,6 +47,9 @@ jobs:
             threads: 2
           - zkvm: zisk
             threads: 1
+          - guest: stateless-validator-ethrex
+            zkvm: zisk
+            ere_profile: ethrex
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -84,6 +87,12 @@ jobs:
           key: ${{ runner.os }}-bin-${{ matrix.guest }}-${{ matrix.zkvm }}-${{ hashFiles('bin/${{ matrix.guest }}/${{ matrix.zkvm }}/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-bin-${{ matrix.guest }}-${{ matrix.zkvm }}-
+
+      - name: Enable Ere profile
+        if: matrix.ere_profile != ''
+        env:
+          ERE_PROFILE: ${{ matrix.ere_profile }}
+        run: echo "ERE_PROFILE=$ERE_PROFILE" >> "$GITHUB_ENV"
 
       - name: Test
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2371,8 +2371,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-blockchain"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2393,8 +2393,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2427,8 +2427,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2452,8 +2452,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2477,8 +2477,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2496,8 +2496,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -2514,8 +2514,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-metrics"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "axum",
  "ethrex-common",
@@ -2530,8 +2530,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-p2p"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -2572,8 +2572,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -2582,8 +2582,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rpc"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "axum",
  "axum-extra",
@@ -2621,8 +2621,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-storage"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2643,8 +2643,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2662,8 +2662,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,8 +2224,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-catalog"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -2234,21 +2234,21 @@ dependencies = [
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-compiler-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ere-dockerized"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -2264,13 +2264,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-prover-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -2286,8 +2286,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-api"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "prost",
  "serde",
@@ -2296,8 +2296,8 @@ dependencies = [
 
 [[package]]
 name = "ere-server-client"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -2308,24 +2308,24 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]
 
 [[package]]
 name = "ere-util-tokio"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "ere-verifier-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "auto_impl",
  "ere-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,11 +115,11 @@ libssz_types = { package = "libssz-types", version = "0.2.2", default-features =
 zkvm-interface = { git = "https://github.com/0xPolygonHermez/zisk.git", tag = "v0.18.0" }
 
 # ere
-ere-codec = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
-ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
-ere-prover-core = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
-ere-util-build = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-codec = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
+ere-prover-core = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
+ere-util-build = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
 
 # local
 guest = { path = "crates/guest", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,12 +94,12 @@ stateless = { git = "https://github.com/paradigmxyz/stateless", rev = "e5480e71a
 tries = { git = "https://github.com/paradigmxyz/stateless", rev = "e5480e71a8031641ff471cad9dc482a7a14b32d5", default-features = false }
 
 # ethrex
-ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
-ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
-ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
-ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
-ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
-ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", rev = "ef81882cfab3eedcf52c788ced3333530ab01fdb", default-features = false }
+ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v15.0.0", default-features = false }
+ethrex-crypto = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v15.0.0", default-features = false }
+ethrex-guest-program = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v15.0.0", default-features = false }
+ethrex-rlp = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v15.0.0", default-features = false }
+ethrex-rpc = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v15.0.0", default-features = false }
+ethrex-vm = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v15.0.0", default-features = false }
 
 # ssz
 libssz = { version = "0.2.2", default-features = false, features = ["alloc"] }

--- a/bin/empty/airbender/Cargo.lock
+++ b/bin/empty/airbender/Cargo.lock
@@ -91,8 +91,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "airbender-sdk",
  "ere-platform-core",
@@ -100,8 +100,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "getrandom"

--- a/bin/empty/airbender/Cargo.toml
+++ b/bin/empty/airbender/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }

--- a/bin/empty/openvm/Cargo.lock
+++ b/bin/empty/openvm/Cargo.lock
@@ -35,13 +35,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/empty/openvm/Cargo.toml
+++ b/bin/empty/openvm/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }

--- a/bin/empty/risc0/Cargo.lock
+++ b/bin/empty/risc0/Cargo.lock
@@ -538,13 +538,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",

--- a/bin/empty/risc0/Cargo.toml
+++ b/bin/empty/risc0/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }

--- a/bin/empty/sp1/Cargo.lock
+++ b/bin/empty/sp1/Cargo.lock
@@ -322,13 +322,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",

--- a/bin/empty/sp1/Cargo.toml
+++ b/bin/empty/sp1/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }

--- a/bin/empty/zisk/Cargo.lock
+++ b/bin/empty/zisk/Cargo.lock
@@ -1331,13 +1331,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "ziskos",

--- a/bin/empty/zisk/Cargo.toml
+++ b/bin/empty/zisk/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
 
 [features]
 cycle-scope = ["ere-platform-zisk/cycle-scope"]

--- a/bin/panic/airbender/Cargo.lock
+++ b/bin/panic/airbender/Cargo.lock
@@ -84,8 +84,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "airbender-sdk",
  "ere-platform-core",
@@ -93,8 +93,8 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "getrandom"

--- a/bin/panic/airbender/Cargo.toml
+++ b/bin/panic/airbender/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }

--- a/bin/panic/openvm/Cargo.lock
+++ b/bin/panic/openvm/Cargo.lock
@@ -28,13 +28,13 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/panic/openvm/Cargo.toml
+++ b/bin/panic/openvm/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }

--- a/bin/panic/risc0/Cargo.lock
+++ b/bin/panic/risc0/Cargo.lock
@@ -531,13 +531,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",

--- a/bin/panic/risc0/Cargo.toml
+++ b/bin/panic/risc0/Cargo.toml
@@ -6,6 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }

--- a/bin/panic/sp1/Cargo.lock
+++ b/bin/panic/sp1/Cargo.lock
@@ -315,13 +315,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",

--- a/bin/panic/sp1/Cargo.toml
+++ b/bin/panic/sp1/Cargo.toml
@@ -6,4 +6,4 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }

--- a/bin/panic/zisk/Cargo.lock
+++ b/bin/panic/zisk/Cargo.lock
@@ -1324,13 +1324,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "ziskos",

--- a/bin/panic/zisk/Cargo.toml
+++ b/bin/panic/zisk/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
 
 [features]
 cycle-scope = ["ere-platform-zisk/cycle-scope"]

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -952,18 +952,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",
@@ -972,8 +972,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-ethrex/risc0/Cargo.lock
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.lock
@@ -1007,8 +1007,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -1039,8 +1039,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1062,8 +1062,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1087,8 +1087,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1106,8 +1106,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",
@@ -1123,8 +1123,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1133,8 +1133,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1152,8 +1152,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more 1.0.0",

--- a/bin/stateless-validator-ethrex/risc0/Cargo.toml
+++ b/bin/stateless-validator-ethrex/risc0/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 c-kzg = { version = "2.1.1", features = ["eip-7594"] }
 
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
     "unstable",
     "getrandom",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -897,18 +897,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",
@@ -916,8 +916,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -951,8 +951,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -985,8 +985,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -1009,8 +1009,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1034,8 +1034,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1053,8 +1053,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -1071,8 +1071,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -1081,8 +1081,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1100,8 +1100,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.toml
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -798,18 +798,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "ziskos",
@@ -817,8 +817,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -852,8 +852,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -884,8 +884,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-crypto"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -905,8 +905,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-guest-program"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -928,8 +928,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-l2-common"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -946,8 +946,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-levm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more",
@@ -963,8 +963,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-rlp"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "ethereum-types",
@@ -973,8 +973,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-trie"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -992,8 +992,8 @@ dependencies = [
 
 [[package]]
 name = "ethrex-vm"
-version = "13.0.0"
-source = "git+https://github.com/lambdaclass/ethrex.git?rev=ef81882cfab3eedcf52c788ced3333530ab01fdb#ef81882cfab3eedcf52c788ced3333530ab01fdb"
+version = "15.0.0"
+source = "git+https://github.com/lambdaclass/ethrex.git?tag=v15.0.0#f902422ada4b4004c4e5e0630987d116661a5dd0"
 dependencies = [
  "bytes",
  "derive_more",

--- a/bin/stateless-validator-ethrex/zisk/Cargo.toml
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", default-features = false, features = ["inputcpy"] }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", default-features = false, features = ["inputcpy"] }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-reth/airbender/Cargo.lock
+++ b/bin/stateless-validator-reth/airbender/Cargo.lock
@@ -1167,13 +1167,13 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-airbender"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "airbender-sdk",
  "ere-platform-core",
@@ -1181,13 +1181,13 @@ dependencies = [
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-reth/airbender/Cargo.toml
+++ b/bin/stateless-validator-reth/airbender/Cargo.toml
@@ -14,7 +14,7 @@ alloy-primitives = { version = "1.5.0", default-features = false, features = [
 revm = { version = "38.0.0", default-features = false, features = ["bn"] }
 
 # ere
-ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-airbender = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -1152,18 +1152,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-openvm"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "openvm",
@@ -1171,8 +1171,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -38,7 +38,7 @@ openvm-keccak256 = { git = "https://github.com/openvm-org/openvm.git", tag = "v1
 aurora-engine-modexp = { version = "1.2.0", default-features = false }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-reth/risc0/Cargo.lock
+++ b/bin/stateless-validator-reth/risc0/Cargo.lock
@@ -1341,18 +1341,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-risc0"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "risc0-zkvm",
@@ -1361,8 +1361,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-reth/risc0/Cargo.toml
+++ b/bin/stateless-validator-reth/risc0/Cargo.toml
@@ -18,7 +18,7 @@ revm = { version = "38.0.0", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", features = [
+ere-platform-risc0 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", features = [
     "std",
     "unstable",
     "getrandom",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -1333,18 +1333,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-sp1"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "sp1-zkvm",
@@ -1352,8 +1352,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -17,7 +17,7 @@ revm = { version = "38.0.0", default-features = false, features = ["bn"] }
 kzg-rs = "0.2.8"
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.11.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.12.1" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth" }

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -1179,18 +1179,18 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ere-codec"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-core"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 
 [[package]]
 name = "ere-platform-zisk"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "ere-platform-core",
  "ziskos",
@@ -1198,8 +1198,8 @@ dependencies = [
 
 [[package]]
 name = "ere-util-build"
-version = "0.11.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.11.0#e1d345c5e4e2b41d1334421310443306ea44f65f"
+version = "0.12.1"
+source = "git+https://github.com/eth-act/ere?tag=v0.12.1#628fa3c49941704d72e7b0e038e7bce5b6d2cd58"
 dependencies = [
  "cargo_metadata",
 ]

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -20,7 +20,7 @@ revm = { version = "38.0.0", default-features = false, features = ["bn"] }
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.11.0", default-features = false, features = [
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.12.1", default-features = false, features = [
     "inputcpy",
 ] }
 


### PR DESCRIPTION
- Bump `ethrex` to `v15.0.0`
- Bump `ere` to `v0.12.1`
- Set `ETH_PROFILE=ethrex` for `stateless-validator-ethrex-zisk` to get AIR cost improvement (see https://github.com/eth-act/ere/pull/374 for more details)