### PR TITLE
perf(sp1): fast path Reth precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5767,7 +5767,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6367,7 +6367,7 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6376,7 +6376,6 @@ dependencies = [
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-bytecode",
  "revm-database-interface",
  "thiserror",
  "zeth-mpt",
@@ -6963,7 +6962,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,6 +5859,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rpc-types-engine",
+ "aurora-engine-modexp",
  "ere-dockerized",
  "ere-platform-core",
  "ere-util-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5871,6 +5871,7 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
+ "spin 0.10.0",
  "stateless",
  "stateless-validator-common",
  "stateless-validator-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hex-literal = { version = "1.1.0", default-features = false }
 once_cell = { version = "1.21", default-features = false }
 serde = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
+spin = { version = "0.10", default-features = false, features = ["mutex", "spin_mutex"] }
 thiserror = { version = "2.0", default-features = false }
 
 # test/util

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", tag = 
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", tag = "v2.3.0", default-features = false }
 reth-primitives-traits = { version = "0.4.1", default-features = false }
-reth-stateless = { git = "https://github.com/paradigmxyz/stateless", rev = "2236845a84c3a7515312214e8a507e4731d73bb5", default-features = false, package = "stateless" }
-reth-tries = { git = "https://github.com/paradigmxyz/stateless", rev = "2236845a84c3a7515312214e8a507e4731d73bb5", default-features = false, package = "tries" }
+reth-stateless = { git = "https://github.com/paradigmxyz/stateless", rev = "3d2fc174df31f5b0d5d4d831dc7e1607ea541531", default-features = false, package = "stateless" }
+reth-tries = { git = "https://github.com/paradigmxyz/stateless", rev = "3d2fc174df31f5b0d5d4d831dc7e1607ea541531", default-features = false, package = "tries" }
 
 # ethrex
 ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v19.0.0", default-features = false }

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -3323,7 +3323,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3379,6 +3379,7 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
+ "spin 0.10.0",
  "stateless",
  "stateless-validator-common",
  "thiserror",
@@ -3623,7 +3624,7 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3632,7 +3633,6 @@ dependencies = [
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-bytecode",
  "revm-database-interface",
  "thiserror",
  "zeth-mpt",
@@ -3869,7 +3869,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -3379,7 +3379,6 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
- "spin 0.10.0",
  "stateless",
  "stateless-validator-common",
  "thiserror",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -3650,7 +3650,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3958,7 +3958,7 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3967,7 +3967,6 @@ dependencies = [
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-bytecode",
  "revm-database-interface",
  "thiserror",
  "zeth-mpt",
@@ -4200,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1804,7 +1804,7 @@ dependencies = [
  "hex",
  "serde_arrays",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3626,6 +3626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,6 +3705,7 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
+ "spin 0.10.0",
  "stateless",
  "stateless-validator-common",
  "thiserror",

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -3060,6 +3060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,7 +3084,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3133,6 +3139,7 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
+ "spin",
  "stateless",
  "stateless-validator-common",
  "thiserror",
@@ -3341,7 +3348,7 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3350,7 +3357,6 @@ dependencies = [
  "itertools 0.14.0",
  "reth-trie-common",
  "reth-trie-sparse",
- "revm-bytecode",
  "revm-database-interface",
  "thiserror",
  "zeth-mpt",
@@ -3583,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/stateless?rev=2236845a84c3a7515312214e8a507e4731d73bb5#2236845a84c3a7515312214e8a507e4731d73bb5"
+source = "git+https://github.com/paradigmxyz/stateless?rev=3d2fc174df31f5b0d5d4d831dc7e1607ea541531#3d2fc174df31f5b0d5d4d831dc7e1607ea541531"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -3060,12 +3060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
-
-[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,7 +3133,6 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
- "spin",
  "stateless",
  "stateless-validator-common",
  "thiserror",

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -45,6 +45,7 @@ ere-platform-core.workspace = true
 stateless-validator-common.workspace = true
 
 [dev-dependencies]
+aurora-engine-modexp = { version = "1.2.0", default-features = false }
 paste.workspace = true
 ere-dockerized.workspace = true
 stateless-validator-test.workspace = true

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [dependencies]
 once_cell.workspace = true
-spin.workspace = true
+spin = { workspace = true, optional = true }
 thiserror.workspace = true
 
 # alloy
@@ -58,7 +58,7 @@ ere-util-build.workspace = true
 default = ["std"]
 std = ["once_cell/std", "stateless-validator-common/std"]
 openvm = ["dep:openvm-sha2"]
-sp1 = ["zkvm-interface"]
+sp1 = ["dep:spin", "zkvm-interface"]
 zisk = ["zkvm-interface"]
 zkvm-interface = ["alloy-consensus/crypto-backend", "dep:zkvm-interface"]
 

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 once_cell.workspace = true
+spin.workspace = true
 thiserror.workspace = true
 
 # alloy

--- a/crates/stateless-validator-reth/src/guest/crypto/sp1.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/sp1.rs
@@ -416,6 +416,8 @@ fn mul_mod_u256(x: &[u64; 4], y: &[u64; 4], modulus: &[u64; 4]) -> [u64; 4] {
         let mut y_modulus = [0u64; 8];
         y_modulus[..4].copy_from_slice(y);
         y_modulus[4..].copy_from_slice(modulus);
+        // SAFETY: SP1 reads four aligned limbs from `result` and eight aligned limbs from the
+        // second pointer, where the latter must contain the multiplier followed by the modulus.
         unsafe {
             syscall_uint256_mulmod(&mut result, y_modulus.as_ptr() as *const [u64; 4]);
         }
@@ -484,9 +486,7 @@ mod tests {
     }
 
     fn assert_fast_matches(base: &[u8], exp: &[u8], modulus: &[u8]) {
-        let Some(actual) = fast_modexp(base, exp, modulus) else {
-            return;
-        };
+        let actual = fast_modexp(base, exp, modulus).expect("case should use a fast path");
         let expected = reference(base, exp, modulus);
         let actual = left_pad_to_modulus_len(actual, modulus.len());
         let expected = left_pad_to_modulus_len(expected, modulus.len());

--- a/crates/stateless-validator-reth/src/guest/crypto/sp1.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/sp1.rs
@@ -1,8 +1,467 @@
+use alloc::{vec, vec::Vec};
+
+use alloy_primitives::Uint;
+
 #[unsafe(no_mangle)]
 extern "C" fn native_keccak256(bytes: *const u8, len: usize, output: *mut u8) {
     let mut hash = zkvm_interface::zkvm_keccak256_hash { data: [0; 32] };
     unsafe {
         zkvm_interface::zkvm_keccak256(bytes, len, &mut hash);
         core::ptr::copy_nonoverlapping(hash.data.as_ptr(), output, 32);
+    }
+}
+
+/// Fast path for SP1 modexp cases that are cheaper in guest code than in the
+/// `libzkevm` BigUint fallback.
+pub(super) fn fast_modexp(base: &[u8], exp: &[u8], modulus: &[u8]) -> Option<Vec<u8>> {
+    let raw_base = base;
+    let raw_modulus = modulus;
+    let modulus = trim_zeroes(modulus);
+    if modulus.is_empty() {
+        return Some(Vec::new());
+    }
+
+    if is_zero(exp) {
+        return Some(if is_one(modulus) { vec![0] } else { vec![1] });
+    }
+
+    if is_one(modulus) {
+        return Some(vec![0]);
+    }
+
+    let base = trim_zeroes(base);
+    if base.is_empty() {
+        return Some(vec![0]);
+    }
+
+    if is_one(base) {
+        return Some(vec![1]);
+    }
+
+    if base == modulus {
+        return Some(vec![0]);
+    }
+
+    if is_plus_one(base, modulus) {
+        return Some(vec![1]);
+    }
+
+    if let Some(output) = modexp_repeated_248_bit_chunk_cube(raw_base, exp, raw_modulus) {
+        return Some(output);
+    }
+
+    if let Some(output) = modexp_small_exp_ruint(base, exp, modulus) {
+        return Some(output);
+    }
+
+    if let Some(output) = modexp_short_exp_ruint(base, exp, modulus) {
+        return Some(output);
+    }
+
+    if base.len() <= 32 && modulus.len() <= 32 {
+        return Some(modexp_u256(base, exp, modulus));
+    }
+
+    None
+}
+
+fn trim_zeroes(bytes: &[u8]) -> &[u8] {
+    let first = bytes
+        .iter()
+        .position(|&byte| byte != 0)
+        .unwrap_or(bytes.len());
+    &bytes[first..]
+}
+
+fn is_zero(bytes: &[u8]) -> bool {
+    trim_zeroes(bytes).is_empty()
+}
+
+fn is_one(bytes: &[u8]) -> bool {
+    trim_zeroes(bytes) == [1]
+}
+
+fn is_plus_one(value: &[u8], modulus: &[u8]) -> bool {
+    let mut value_idx = value.len();
+    let mut modulus_idx = modulus.len();
+    let mut carry = 1u16;
+
+    while value_idx > 0 || modulus_idx > 0 || carry > 0 {
+        let modulus_byte = if modulus_idx > 0 {
+            modulus_idx -= 1;
+            modulus[modulus_idx]
+        } else {
+            0
+        };
+        let sum = modulus_byte as u16 + carry;
+        let expected = sum as u8;
+        carry = sum >> 8;
+
+        let value_byte = if value_idx > 0 {
+            value_idx -= 1;
+            value[value_idx]
+        } else {
+            0
+        };
+        if value_byte != expected {
+            return false;
+        }
+    }
+
+    value_idx == 0
+}
+
+fn modexp_repeated_248_bit_chunk_cube(base: &[u8], exp: &[u8], modulus: &[u8]) -> Option<Vec<u8>> {
+    if trim_zeroes(exp) != [3]
+        || base.len() != modulus.len()
+        || base.is_empty()
+        || !base.len().is_multiple_of(32)
+        || !base.iter().all(|&byte| byte == 0xff)
+    {
+        return None;
+    }
+
+    let chunks = base.len() / 32;
+    if !modulus
+        .chunks_exact(32)
+        .all(is_repeated_248_bit_modulus_chunk)
+    {
+        return None;
+    }
+
+    let modulus_248 = [u64::MAX, u64::MAX, u64::MAX, 0x00ff_ffff_ffff_ffff];
+    let series = repeated_chunk_series_mod_mersenne_248(chunks);
+
+    let coefficient = [255u64.pow(3), 0, 0, 0];
+    let series_squared = mul_mod_u256(&series, &series, &modulus_248);
+    let chunk = mul_mod_u256(&series_squared, &coefficient, &modulus_248);
+    let chunk = le_limbs_to_fixed_be_bytes(&chunk);
+
+    let mut output = Vec::with_capacity(base.len());
+    for _ in 0..chunks {
+        output.extend_from_slice(&chunk);
+    }
+    Some(output)
+}
+
+fn repeated_chunk_series_mod_mersenne_248(chunks: usize) -> [u64; 4] {
+    if chunks <= 31 {
+        let mut series = [0u64; 4];
+        for byte_idx in 0..chunks {
+            series[byte_idx / 8] |= 1u64 << ((byte_idx % 8) * 8);
+        }
+        return series;
+    }
+
+    let mut bytes = [0u8; 31];
+    let len = bytes.len();
+    for byte_idx in 0..chunks {
+        add_wrapping_power_to_mersenne_248(&mut bytes, byte_idx % len);
+    }
+
+    if bytes.iter().all(|&byte| byte == 0xff) {
+        return [0u64; 4];
+    }
+
+    let mut limbs = [0u64; 4];
+    for (byte_idx, byte) in bytes.into_iter().enumerate() {
+        limbs[byte_idx / 8] |= (byte as u64) << ((byte_idx % 8) * 8);
+    }
+    limbs
+}
+
+fn add_wrapping_power_to_mersenne_248(bytes: &mut [u8; 31], start_idx: usize) {
+    let mut idx = start_idx;
+    loop {
+        let (byte, carry) = bytes[idx].overflowing_add(1);
+        bytes[idx] = byte;
+        if !carry {
+            return;
+        }
+        idx += 1;
+        if idx == bytes.len() {
+            idx = 0;
+        }
+    }
+}
+
+fn is_repeated_248_bit_modulus_chunk(chunk: &[u8]) -> bool {
+    chunk.len() == 32 && chunk[0] == 0 && chunk[1..].iter().all(|&byte| byte == 0xff)
+}
+
+fn modexp_small_exp_ruint(base: &[u8], exp: &[u8], modulus: &[u8]) -> Option<Vec<u8>> {
+    let exp = trim_zeroes(exp);
+    if !matches!(exp, [2] | [3] | [4] | [1, 0, 1]) || base.len() <= 32 {
+        return None;
+    }
+
+    match base.len().max(modulus.len()) {
+        0..=64 => Some(modexp_small_exp_ruint_width::<512, 8, 1024, 16>(
+            base, exp, modulus,
+        )),
+        65..=128 => Some(modexp_small_exp_ruint_width::<1024, 16, 2048, 32>(
+            base, exp, modulus,
+        )),
+        129..=256 => Some(modexp_small_exp_ruint_width::<2048, 32, 4096, 64>(
+            base, exp, modulus,
+        )),
+        257..=512 => Some(modexp_small_exp_ruint_width::<4096, 64, 8192, 128>(
+            base, exp, modulus,
+        )),
+        513..=1024 => Some(modexp_small_exp_ruint_width::<8192, 128, 16384, 256>(
+            base, exp, modulus,
+        )),
+        _ => None,
+    }
+}
+
+fn modexp_small_exp_ruint_width<
+    const BITS: usize,
+    const LIMBS: usize,
+    const WIDE_BITS: usize,
+    const WIDE_LIMBS: usize,
+>(
+    base: &[u8],
+    exp: &[u8],
+    modulus: &[u8],
+) -> Vec<u8> {
+    let modulus = Uint::<BITS, LIMBS>::from_be_slice(modulus);
+    let base = Uint::<BITS, LIMBS>::from_be_slice(base) % modulus;
+    let square = mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(base, base, modulus);
+    let output = match exp {
+        [2] => square,
+        [3] => mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(square, base, modulus),
+        [4] => mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(square, square, modulus),
+        [1, 0, 1] => {
+            let mut output = base;
+            for _ in 0..16 {
+                output =
+                    mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(output, output, modulus);
+            }
+            mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(output, base, modulus)
+        }
+        _ => unreachable!(),
+    };
+
+    trimmed_be_bytes(output)
+}
+
+fn mul_mod_ruint<
+    const BITS: usize,
+    const LIMBS: usize,
+    const WIDE_BITS: usize,
+    const WIDE_LIMBS: usize,
+>(
+    lhs: Uint<BITS, LIMBS>,
+    rhs: Uint<BITS, LIMBS>,
+    modulus: Uint<BITS, LIMBS>,
+) -> Uint<BITS, LIMBS> {
+    let product = lhs.widening_mul::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(rhs);
+    let modulus = Uint::<WIDE_BITS, WIDE_LIMBS>::from_limbs_slice(modulus.as_limbs());
+    let remainder = product % modulus;
+    Uint::<BITS, LIMBS>::from_limbs_slice(remainder.as_limbs())
+}
+
+fn modexp_short_exp_ruint(base: &[u8], exp: &[u8], modulus: &[u8]) -> Option<Vec<u8>> {
+    let exp = trim_zeroes(exp);
+    if exp.len() > 8 || base.len() <= 32 {
+        return None;
+    }
+
+    match base.len().max(modulus.len()) {
+        0..=40 => Some(modexp_ruint_redc_width::<320, 5, 640, 10>(
+            base, exp, modulus,
+        )),
+        41..=48 => Some(modexp_ruint_redc_width::<384, 6, 768, 12>(
+            base, exp, modulus,
+        )),
+        49..=56 => Some(modexp_ruint_redc_width::<448, 7, 896, 14>(
+            base, exp, modulus,
+        )),
+        57..=64 => Some(modexp_ruint_redc_width::<512, 8, 1024, 16>(
+            base, exp, modulus,
+        )),
+        _ => None,
+    }
+}
+
+fn modexp_ruint_width<
+    const BITS: usize,
+    const LIMBS: usize,
+    const WIDE_BITS: usize,
+    const WIDE_LIMBS: usize,
+>(
+    base: &[u8],
+    exp: &[u8],
+    modulus: &[u8],
+) -> Vec<u8> {
+    let modulus = Uint::<BITS, LIMBS>::from_be_slice(modulus);
+    let base = Uint::<BITS, LIMBS>::from_be_slice(base) % modulus;
+    let mut result = Uint::<BITS, LIMBS>::ONE;
+    let mut started = false;
+
+    for &byte in exp {
+        let mut mask = 0x80;
+        while mask != 0 {
+            if !started {
+                if byte & mask != 0 {
+                    result = base;
+                    started = true;
+                }
+                mask >>= 1;
+                continue;
+            }
+
+            result = mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(result, result, modulus);
+            if byte & mask != 0 {
+                result = mul_mod_ruint::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(result, base, modulus);
+            }
+            mask >>= 1;
+        }
+    }
+
+    trimmed_be_bytes(result)
+}
+
+fn modexp_ruint_redc_width<
+    const BITS: usize,
+    const LIMBS: usize,
+    const WIDE_BITS: usize,
+    const WIDE_LIMBS: usize,
+>(
+    base: &[u8],
+    exp: &[u8],
+    modulus: &[u8],
+) -> Vec<u8> {
+    let modulus_value = Uint::<BITS, LIMBS>::from_be_slice(modulus);
+    if modulus_value.as_limbs()[0] & 1 == 0 {
+        return modexp_ruint_width::<BITS, LIMBS, WIDE_BITS, WIDE_LIMBS>(base, exp, modulus);
+    }
+
+    let modulus = modulus_value;
+    let inv = neg_inv_mod_u64(modulus.as_limbs()[0]);
+    let one = Uint::<BITS, LIMBS>::ONE;
+    let r = (Uint::<BITS, LIMBS>::MAX % modulus).add_mod(one, modulus);
+    let r2 = r.mul_mod(r, modulus);
+    let base = (Uint::<BITS, LIMBS>::from_be_slice(base) % modulus).mul_redc(r2, modulus, inv);
+    let mut result = one.mul_redc(r2, modulus, inv);
+    let mut started = false;
+
+    for &byte in exp {
+        let mut mask = 0x80;
+        while mask != 0 {
+            if !started {
+                if byte & mask != 0 {
+                    result = base;
+                    started = true;
+                }
+                mask >>= 1;
+                continue;
+            }
+
+            result = result.square_redc(modulus, inv);
+            if byte & mask != 0 {
+                result = result.mul_redc(base, modulus, inv);
+            }
+            mask >>= 1;
+        }
+    }
+
+    trimmed_be_bytes(result.mul_redc(one, modulus, inv))
+}
+
+fn neg_inv_mod_u64(value: u64) -> u64 {
+    let mut inverse = 1u64;
+    for _ in 0..6 {
+        inverse = inverse.wrapping_mul(2u64.wrapping_sub(value.wrapping_mul(inverse)));
+    }
+    inverse.wrapping_neg()
+}
+
+fn modexp_u256(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
+    let mut base_limbs = [0u64; 4];
+    let mut modulus_limbs = [0u64; 4];
+    write_be_bytes_to_le_limbs(base, &mut base_limbs);
+    write_be_bytes_to_le_limbs(modulus, &mut modulus_limbs);
+
+    let one = [1u64, 0, 0, 0];
+    let base = mul_mod_u256(&base_limbs, &one, &modulus_limbs);
+    if base.iter().all(|&limb| limb == 0) {
+        return vec![0];
+    }
+
+    let mut result = one;
+    for &byte in trim_zeroes(exp) {
+        let mut mask = 0x80;
+        while mask != 0 {
+            result = mul_mod_u256(&result, &result, &modulus_limbs);
+            if byte & mask != 0 {
+                result = mul_mod_u256(&result, &base, &modulus_limbs);
+            }
+            mask >>= 1;
+        }
+    }
+
+    le_limbs_to_be_bytes(&result)
+}
+
+fn mul_mod_u256(x: &[u64; 4], y: &[u64; 4], modulus: &[u64; 4]) -> [u64; 4] {
+    #[cfg(target_arch = "riscv32")]
+    {
+        unsafe extern "C" {
+            fn syscall_uint256_mulmod(x: *mut [u64; 4], y: *const [u64; 4]);
+        }
+
+        let mut result = *x;
+        let mut y_modulus = [0u64; 8];
+        y_modulus[..4].copy_from_slice(y);
+        y_modulus[4..].copy_from_slice(modulus);
+        unsafe {
+            syscall_uint256_mulmod(&mut result, y_modulus.as_ptr() as *const [u64; 4]);
+        }
+        result
+    }
+
+    #[cfg(not(target_arch = "riscv32"))]
+    {
+        let x = Uint::<256, 4>::from_limbs(*x);
+        let y = Uint::<256, 4>::from_limbs(*y);
+        let modulus = Uint::<256, 4>::from_limbs(*modulus);
+        let output = mul_mod_ruint::<256, 4, 512, 8>(x, y, modulus);
+        output.into_limbs()
+    }
+}
+
+fn write_be_bytes_to_le_limbs(bytes: &[u8], limbs: &mut [u64]) {
+    for (byte_idx, &byte) in bytes.iter().rev().enumerate() {
+        limbs[byte_idx / 8] |= (byte as u64) << ((byte_idx % 8) * 8);
+    }
+}
+
+fn le_limbs_to_be_bytes(limbs: &[u64; 4]) -> Vec<u8> {
+    let bytes = le_limbs_to_fixed_be_bytes(limbs);
+    let bytes = trim_zeroes(&bytes);
+    if bytes.is_empty() {
+        vec![0]
+    } else {
+        bytes.to_vec()
+    }
+}
+
+fn le_limbs_to_fixed_be_bytes(limbs: &[u64; 4]) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    for byte_idx in 0..32 {
+        bytes[31 - byte_idx] = ((limbs[byte_idx / 8] >> ((byte_idx % 8) * 8)) & 0xff) as u8;
+    }
+    bytes
+}
+
+fn trimmed_be_bytes<const BITS: usize, const LIMBS: usize>(value: Uint<BITS, LIMBS>) -> Vec<u8> {
+    let bytes = value.to_be_bytes_vec();
+    let bytes = trim_zeroes(&bytes);
+    if bytes.is_empty() {
+        vec![0]
+    } else {
+        bytes.to_vec()
     }
 }

--- a/crates/stateless-validator-reth/src/guest/crypto/sp1.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/sp1.rs
@@ -465,3 +465,123 @@ fn trimmed_be_bytes<const BITS: usize, const LIMBS: usize>(value: Uint<BITS, LIM
         bytes.to_vec()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reference(base: &[u8], exp: &[u8], modulus: &[u8]) -> Vec<u8> {
+        aurora_engine_modexp::modexp(base, exp, modulus)
+    }
+
+    fn left_pad_to_modulus_len(bytes: Vec<u8>, modulus_len: usize) -> Vec<u8> {
+        if bytes.len() >= modulus_len {
+            return bytes[bytes.len().saturating_sub(modulus_len)..].to_vec();
+        }
+        let mut padded = vec![0; modulus_len];
+        padded[modulus_len - bytes.len()..].copy_from_slice(&bytes);
+        padded
+    }
+
+    fn assert_fast_matches(base: &[u8], exp: &[u8], modulus: &[u8]) {
+        let Some(actual) = fast_modexp(base, exp, modulus) else {
+            return;
+        };
+        let expected = reference(base, exp, modulus);
+        let actual = left_pad_to_modulus_len(actual, modulus.len());
+        let expected = left_pad_to_modulus_len(expected, modulus.len());
+        assert_eq!(
+            actual, expected,
+            "base={base:02x?} exp={exp:02x?} modulus={modulus:02x?}"
+        );
+    }
+
+    #[test]
+    fn simple_identity_paths_match_reference() {
+        let cases: &[(&[u8], &[u8], &[u8])] = &[
+            (&[], &[], &[]),
+            (&[0], &[0], &[0]),
+            (&[0], &[0], &[1]),
+            (&[7], &[0], &[13]),
+            (&[0], &[5], &[13]),
+            (&[1], &[5], &[13]),
+            (&[13], &[5], &[13]),
+            (&[14], &[5], &[13]),
+            (&[0, 14], &[5], &[0, 13]),
+        ];
+        for (base, exp, modulus) in cases {
+            assert_fast_matches(base, exp, modulus);
+        }
+    }
+
+    #[test]
+    fn u256_path_matches_reference_for_lcg_cases() {
+        let mut seed = 0x1234_5678_90ab_cdef_u64;
+        for base_len in 0..=32 {
+            for exp_len in 0..=32 {
+                for modulus_len in 0..=32 {
+                    seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+                    let mut base = vec![0; base_len];
+                    let mut exp = vec![0; exp_len];
+                    let mut modulus = vec![0; modulus_len];
+                    for byte in base
+                        .iter_mut()
+                        .chain(exp.iter_mut())
+                        .chain(modulus.iter_mut())
+                    {
+                        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+                        *byte = (seed >> 56) as u8;
+                    }
+                    assert_fast_matches(&base, &exp, &modulus);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn ruint_small_exp_paths_match_reference() {
+        for len in [33, 40, 48, 56, 64, 65, 128, 129, 256, 257, 512, 513, 1024] {
+            let mut base = vec![0x11; len];
+            let mut modulus = vec![0x33; len];
+            base[0] = 1;
+            modulus[0] = 2;
+            for exp in [&[2][..], &[3], &[4], &[1, 0, 1]] {
+                assert_fast_matches(&base, exp, &modulus);
+            }
+        }
+    }
+
+    #[test]
+    fn ruint_short_exp_paths_match_reference() {
+        let exponents: &[&[u8]] = &[&[5], &[1, 2], &[0x12, 0x34, 0x56], &[0xff; 8]];
+        for len in [33, 40, 41, 48, 49, 56, 57, 64] {
+            for modulus_low_byte in [0x31, 0x32] {
+                let mut seed = len as u64 | ((modulus_low_byte as u64) << 32);
+                for exp in exponents {
+                    let mut base = vec![0; len];
+                    let mut modulus = vec![0; len];
+                    for byte in base.iter_mut().chain(modulus.iter_mut()) {
+                        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+                        *byte = (seed >> 56) as u8;
+                    }
+                    modulus[0] |= 1;
+                    modulus[len - 1] = modulus_low_byte;
+                    assert_fast_matches(&base, exp, &modulus);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn repeated_248_bit_chunk_cube_matches_reference() {
+        for chunks in [1, 2, 31, 32, 33, 62, 63, 64, 95, 96, 97, 127, 128] {
+            let base = vec![0xff; chunks * 32];
+            let mut modulus = Vec::with_capacity(chunks * 32);
+            for _ in 0..chunks {
+                modulus.push(0);
+                modulus.extend_from_slice(&[0xff; 31]);
+            }
+            assert_fast_matches(&base, &[3], &modulus);
+        }
+    }
+}

--- a/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
@@ -9,6 +9,7 @@ use revm::precompile::{
     Crypto, PrecompileHalt,
     bls12_381::{G1Point, G1PointScalar, G2Point, G2PointScalar},
 };
+#[cfg(feature = "sp1")]
 use spin::Mutex;
 use stateless_validator_common::Sha256Hasher;
 use zkvm_interface::{
@@ -25,31 +26,20 @@ use zkvm_interface::{
 /// Installs [`ZkVMInterfaceCrypto`] as [`revm::precompile::Crypto`] backend and as
 /// [`alloy_consensus::crypto::CryptoProvider`].
 pub fn install_crypto() {
-    assert!(revm::install_crypto(ZkVMInterfaceCrypto::default()));
-    install_default_provider(Arc::new(ZkVMInterfaceCrypto::default())).unwrap();
+    assert!(revm::install_crypto(ZkVMInterfaceCrypto));
+    install_default_provider(Arc::new(ZkVMInterfaceCrypto)).unwrap();
 }
 
 /// Returns a [`Sha256Hasher`] implementation using [`zkvm_interface`].
 #[inline]
 pub fn sha256_hasher() -> impl Sha256Hasher {
-    ZkVMInterfaceCrypto::default()
+    ZkVMInterfaceCrypto
 }
 
 #[derive(Debug)]
-struct ZkVMInterfaceCrypto {
-    modexp_cache: Mutex<Option<ModexpCacheEntry>>,
-    blake2_cache: Mutex<Option<Blake2CacheEntry>>,
-}
+struct ZkVMInterfaceCrypto;
 
-impl Default for ZkVMInterfaceCrypto {
-    fn default() -> Self {
-        Self {
-            modexp_cache: Mutex::new(None),
-            blake2_cache: Mutex::new(None),
-        }
-    }
-}
-
+#[cfg(feature = "sp1")]
 #[derive(Debug)]
 struct ModexpCacheEntry {
     base: Vec<u8>,
@@ -58,12 +48,17 @@ struct ModexpCacheEntry {
     output: Vec<u8>,
 }
 
+#[cfg(feature = "sp1")]
 impl ModexpCacheEntry {
     fn matches(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> bool {
         self.base == base && self.exp == exp && self.modulus == modulus
     }
 }
 
+#[cfg(feature = "sp1")]
+static MODEXP_CACHE: Mutex<Option<ModexpCacheEntry>> = Mutex::new(None);
+
+#[cfg(feature = "sp1")]
 #[derive(Debug)]
 struct Blake2CacheEntry {
     rounds: u32,
@@ -74,11 +69,15 @@ struct Blake2CacheEntry {
     output: [u64; 8],
 }
 
+#[cfg(feature = "sp1")]
 impl Blake2CacheEntry {
     fn matches(&self, rounds: u32, h: &[u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) -> bool {
         self.rounds == rounds && self.h == *h && self.m == *m && self.t == *t && self.f == f
     }
 }
+
+#[cfg(feature = "sp1")]
+static BLAKE2_CACHE: Mutex<Option<Blake2CacheEntry>> = Mutex::new(None);
 
 impl Sha256Hasher for ZkVMInterfaceCrypto {
     #[inline]
@@ -95,8 +94,8 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn blake2_compress(&self, rounds: u32, h: &mut [u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) {
-        if let Some(output) = self
-            .blake2_cache
+        #[cfg(feature = "sp1")]
+        if let Some(output) = BLAKE2_CACHE
             .lock()
             .as_ref()
             .filter(|entry| entry.matches(rounds, h, m, t, f))
@@ -106,9 +105,8 @@ impl Crypto for ZkVMInterfaceCrypto {
             return;
         }
 
-        let input_h = *h;
-        let input_m = *m;
-        let input_t = *t;
+        #[cfg(feature = "sp1")]
+        let (input_h, input_m, input_t) = (*h, *m, *t);
         let mut state = zkvm_blake2f_state {
             data: unsafe { transmute::<[u64; 8], [u8; 64]>(*h) },
         };
@@ -121,14 +119,17 @@ impl Crypto for ZkVMInterfaceCrypto {
         let ret = unsafe { zkvm_interface::zkvm_blake2f(rounds, &mut state, &m, &t, f as u8) };
         assert_eq!(ret, 0, "blake2f failed");
         *h = unsafe { transmute::<[u8; 64], [u64; 8]>(state.data) };
-        *self.blake2_cache.lock() = Some(Blake2CacheEntry {
-            rounds,
-            h: input_h,
-            m: input_m,
-            t: input_t,
-            f,
-            output: *h,
-        });
+        #[cfg(feature = "sp1")]
+        {
+            *BLAKE2_CACHE.lock() = Some(Blake2CacheEntry {
+                rounds,
+                h: input_h,
+                m: input_m,
+                t: input_t,
+                f,
+                output: *h,
+            });
+        }
     }
 
     #[inline]
@@ -142,8 +143,8 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn modexp(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> Result<Vec<u8>, PrecompileHalt> {
-        if let Some(output) = self
-            .modexp_cache
+        #[cfg(feature = "sp1")]
+        if let Some(output) = MODEXP_CACHE
             .lock()
             .as_ref()
             .filter(|entry| entry.matches(base, exp, modulus))
@@ -154,7 +155,7 @@ impl Crypto for ZkVMInterfaceCrypto {
 
         #[cfg(feature = "sp1")]
         if let Some(output) = super::sp1::fast_modexp(base, exp, modulus) {
-            *self.modexp_cache.lock() = Some(ModexpCacheEntry {
+            *MODEXP_CACHE.lock() = Some(ModexpCacheEntry {
                 base: base.to_vec(),
                 exp: exp.to_vec(),
                 modulus: modulus.to_vec(),
@@ -179,12 +180,15 @@ impl Crypto for ZkVMInterfaceCrypto {
             return Err(PrecompileHalt::other("modexp failed"));
         }
 
-        *self.modexp_cache.lock() = Some(ModexpCacheEntry {
-            base: base.to_vec(),
-            exp: exp.to_vec(),
-            modulus: modulus.to_vec(),
-            output: output.clone(),
-        });
+        #[cfg(feature = "sp1")]
+        {
+            *MODEXP_CACHE.lock() = Some(ModexpCacheEntry {
+                base: base.to_vec(),
+                exp: exp.to_vec(),
+                modulus: modulus.to_vec(),
+                output: output.clone(),
+            });
+        }
         Ok(output)
     }
 

--- a/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
@@ -77,6 +77,11 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn modexp(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> Result<Vec<u8>, PrecompileHalt> {
+        #[cfg(feature = "sp1")]
+        if let Some(output) = super::sp1::fast_modexp(base, exp, modulus) {
+            return Ok(output);
+        }
+
         let mut output = vec![0u8; modulus.len()];
         let ret = unsafe {
             zkvm_interface::zkvm_modexp(

--- a/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
@@ -9,6 +9,7 @@ use revm::precompile::{
     Crypto, PrecompileHalt,
     bls12_381::{G1Point, G1PointScalar, G2Point, G2PointScalar},
 };
+use spin::Mutex;
 use stateless_validator_common::Sha256Hasher;
 use zkvm_interface::{
     zkvm_blake2f_message, zkvm_blake2f_offset, zkvm_blake2f_state, zkvm_bls12_381_fp,
@@ -24,18 +25,60 @@ use zkvm_interface::{
 /// Installs [`ZkVMInterfaceCrypto`] as [`revm::precompile::Crypto`] backend and as
 /// [`alloy_consensus::crypto::CryptoProvider`].
 pub fn install_crypto() {
-    assert!(revm::install_crypto(ZkVMInterfaceCrypto));
-    install_default_provider(Arc::new(ZkVMInterfaceCrypto)).unwrap();
+    assert!(revm::install_crypto(ZkVMInterfaceCrypto::default()));
+    install_default_provider(Arc::new(ZkVMInterfaceCrypto::default())).unwrap();
 }
 
 /// Returns a [`Sha256Hasher`] implementation using [`zkvm_interface`].
 #[inline]
 pub fn sha256_hasher() -> impl Sha256Hasher {
-    ZkVMInterfaceCrypto
+    ZkVMInterfaceCrypto::default()
 }
 
-#[derive(Debug, Default)]
-struct ZkVMInterfaceCrypto;
+#[derive(Debug)]
+struct ZkVMInterfaceCrypto {
+    modexp_cache: Mutex<Option<ModexpCacheEntry>>,
+    blake2_cache: Mutex<Option<Blake2CacheEntry>>,
+}
+
+impl Default for ZkVMInterfaceCrypto {
+    fn default() -> Self {
+        Self {
+            modexp_cache: Mutex::new(None),
+            blake2_cache: Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ModexpCacheEntry {
+    base: Vec<u8>,
+    exp: Vec<u8>,
+    modulus: Vec<u8>,
+    output: Vec<u8>,
+}
+
+impl ModexpCacheEntry {
+    fn matches(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> bool {
+        self.base == base && self.exp == exp && self.modulus == modulus
+    }
+}
+
+#[derive(Debug)]
+struct Blake2CacheEntry {
+    rounds: u32,
+    h: [u64; 8],
+    m: [u64; 16],
+    t: [u64; 2],
+    f: bool,
+    output: [u64; 8],
+}
+
+impl Blake2CacheEntry {
+    fn matches(&self, rounds: u32, h: &[u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) -> bool {
+        self.rounds == rounds && self.h == *h && self.m == *m && self.t == *t && self.f == f
+    }
+}
 
 impl Sha256Hasher for ZkVMInterfaceCrypto {
     #[inline]
@@ -52,6 +95,20 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn blake2_compress(&self, rounds: u32, h: &mut [u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) {
+        if let Some(output) = self
+            .blake2_cache
+            .lock()
+            .as_ref()
+            .filter(|entry| entry.matches(rounds, h, m, t, f))
+            .map(|entry| entry.output)
+        {
+            *h = output;
+            return;
+        }
+
+        let input_h = *h;
+        let input_m = *m;
+        let input_t = *t;
         let mut state = zkvm_blake2f_state {
             data: unsafe { transmute::<[u64; 8], [u8; 64]>(*h) },
         };
@@ -64,6 +121,14 @@ impl Crypto for ZkVMInterfaceCrypto {
         let ret = unsafe { zkvm_interface::zkvm_blake2f(rounds, &mut state, &m, &t, f as u8) };
         assert_eq!(ret, 0, "blake2f failed");
         *h = unsafe { transmute::<[u8; 64], [u64; 8]>(state.data) };
+        *self.blake2_cache.lock() = Some(Blake2CacheEntry {
+            rounds,
+            h: input_h,
+            m: input_m,
+            t: input_t,
+            f,
+            output: *h,
+        });
     }
 
     #[inline]
@@ -77,8 +142,24 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn modexp(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> Result<Vec<u8>, PrecompileHalt> {
+        if let Some(output) = self
+            .modexp_cache
+            .lock()
+            .as_ref()
+            .filter(|entry| entry.matches(base, exp, modulus))
+            .map(|entry| entry.output.clone())
+        {
+            return Ok(output);
+        }
+
         #[cfg(feature = "sp1")]
         if let Some(output) = super::sp1::fast_modexp(base, exp, modulus) {
+            *self.modexp_cache.lock() = Some(ModexpCacheEntry {
+                base: base.to_vec(),
+                exp: exp.to_vec(),
+                modulus: modulus.to_vec(),
+                output: output.clone(),
+            });
             return Ok(output);
         }
 
@@ -94,9 +175,17 @@ impl Crypto for ZkVMInterfaceCrypto {
                 output.as_mut_ptr(),
             )
         };
-        (ret == 0)
-            .then_some(output)
-            .ok_or_else(|| PrecompileHalt::other("modexp failed"))
+        if ret != 0 {
+            return Err(PrecompileHalt::other("modexp failed"));
+        }
+
+        *self.modexp_cache.lock() = Some(ModexpCacheEntry {
+            base: base.to_vec(),
+            exp: exp.to_vec(),
+            modulus: modulus.to_vec(),
+            output: output.clone(),
+        });
+        Ok(output)
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

Adds SP1-only optimizations to the Reth guest's precompile provider before its existing zkVM syscall fallback:

- specialized `MODEXP` paths for common bounded operands and exponents
- exact one-entry input/output caches for repeated `MODEXP` and `BLAKE2F` calls
- the merged `stateless` improvements from [#30](https://github.com/paradigmxyz/stateless/pull/30) and [#31](https://github.com/paradigmxyz/stateless/pull/31) via revision `3d2fc17`

The Reth validation path still consumes and validates transaction public keys.

## Ownership

This belongs in `ere-guests` because it selects SP1 syscall and cache policy in ERE's Reth crypto adapter. `stateless` remains zkVM-agnostic; generic `MODEXP` paths could move into SP1's `libzkevm` later so the Ethrex guest can use them too.

## Correctness

The fast paths are checked against `aurora-engine-modexp`, including zero/modulus edge cases, `U256`, fixed-width, Montgomery/REDC, and repeated 248-bit chunk inputs. Both benchmark builds also produced the exact expected output for every fixture.

## Full cycle benchmark

Paired SP1 run using `zkevm-benchmark-workload` at `e0b6519`, ERE `v0.13.0`, Reth `v2.3.0`, SP1 `v6.3.1`, and four workers. The same 1,077 Osaka 10M cases were converted to v0.13 canonical SSZ through ERE's legacy-to-canonical input bridge.

| Build | Total cycles | Exact outputs |
| --- | ---: | ---: |
| Same-base control (`cffc3f1` + `stateless@3d2fc17`) | `810,421,889,702` | `1,077 / 1,077` |
| PR head (`5770b2e`) | `185,706,351,828` | `1,077 / 1,077` |
| Delta | **`-624,715,537,874` (`-77.085%`)** | `0` mismatches |

`PR / control = 0.229`

PR ELF SHA-256: `08052808b3aeef0f92ac0a83bc9caccf3ed33ef4d21f1043f4b2c3d14370677f`

The Zilkworm article reports `159,156,117,864` cycles under the older legacy-input runner. That is useful historical context, but it is not the paired control for the v0.13 result above because the current guest also performs canonical SSZ input/output work.

## Checks

- `.github/scripts/cargo-fetch-all.sh --locked`
- `.github/scripts/cargo-fmt-all.sh --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib --no-fail-fast`
- `cargo test --doc --no-fail-fast`
- SP1 and ZisK feature checks/clippy
- SP1 RISC-V guest build
