### PR TITLE
perf(sp1): cache repeated Reth precompile inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5871,6 +5871,7 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
+ "spin 0.10.0",
  "stateless",
  "stateless-validator-common",
  "stateless-validator-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ hex-literal = { version = "1.1.0", default-features = false }
 once_cell = { version = "1.21", default-features = false }
 serde = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }
+spin = { version = "0.10", default-features = false, features = ["mutex", "spin_mutex"] }
 thiserror = { version = "2.0", default-features = false }
 
 # test/util

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -1804,7 +1804,7 @@ dependencies = [
  "hex",
  "serde_arrays",
  "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3626,6 +3626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3699,6 +3705,7 @@ dependencies = [
  "reth-payload-validator",
  "reth-primitives-traits",
  "revm",
+ "spin 0.10.0",
  "stateless",
  "stateless-validator-common",
  "thiserror",

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 once_cell.workspace = true
+spin.workspace = true
 thiserror.workspace = true
 
 # alloy

--- a/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
+++ b/crates/stateless-validator-reth/src/guest/crypto/zkvm_interface.rs
@@ -9,6 +9,7 @@ use revm::precompile::{
     Crypto, PrecompileHalt,
     bls12_381::{G1Point, G1PointScalar, G2Point, G2PointScalar},
 };
+use spin::Mutex;
 use stateless_validator_common::Sha256Hasher;
 use zkvm_interface::{
     zkvm_blake2f_message, zkvm_blake2f_offset, zkvm_blake2f_state, zkvm_bls12_381_fp,
@@ -24,18 +25,60 @@ use zkvm_interface::{
 /// Installs [`ZkVMInterfaceCrypto`] as [`revm::precompile::Crypto`] backend and as
 /// [`alloy_consensus::crypto::CryptoProvider`].
 pub fn install_crypto() {
-    assert!(revm::install_crypto(ZkVMInterfaceCrypto));
-    install_default_provider(Arc::new(ZkVMInterfaceCrypto)).unwrap();
+    assert!(revm::install_crypto(ZkVMInterfaceCrypto::default()));
+    install_default_provider(Arc::new(ZkVMInterfaceCrypto::default())).unwrap();
 }
 
 /// Returns a [`Sha256Hasher`] implementation using [`zkvm_interface`].
 #[inline]
 pub fn sha256_hasher() -> impl Sha256Hasher {
-    ZkVMInterfaceCrypto
+    ZkVMInterfaceCrypto::default()
 }
 
-#[derive(Debug, Default)]
-struct ZkVMInterfaceCrypto;
+#[derive(Debug)]
+struct ZkVMInterfaceCrypto {
+    modexp_cache: Mutex<Option<ModexpCacheEntry>>,
+    blake2_cache: Mutex<Option<Blake2CacheEntry>>,
+}
+
+impl Default for ZkVMInterfaceCrypto {
+    fn default() -> Self {
+        Self {
+            modexp_cache: Mutex::new(None),
+            blake2_cache: Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ModexpCacheEntry {
+    base: Vec<u8>,
+    exp: Vec<u8>,
+    modulus: Vec<u8>,
+    output: Vec<u8>,
+}
+
+impl ModexpCacheEntry {
+    fn matches(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> bool {
+        self.base == base && self.exp == exp && self.modulus == modulus
+    }
+}
+
+#[derive(Debug)]
+struct Blake2CacheEntry {
+    rounds: u32,
+    h: [u64; 8],
+    m: [u64; 16],
+    t: [u64; 2],
+    f: bool,
+    output: [u64; 8],
+}
+
+impl Blake2CacheEntry {
+    fn matches(&self, rounds: u32, h: &[u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) -> bool {
+        self.rounds == rounds && self.h == *h && self.m == *m && self.t == *t && self.f == f
+    }
+}
 
 impl Sha256Hasher for ZkVMInterfaceCrypto {
     #[inline]
@@ -52,6 +95,20 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn blake2_compress(&self, rounds: u32, h: &mut [u64; 8], m: &[u64; 16], t: &[u64; 2], f: bool) {
+        if let Some(output) = self
+            .blake2_cache
+            .lock()
+            .as_ref()
+            .filter(|entry| entry.matches(rounds, h, m, t, f))
+            .map(|entry| entry.output)
+        {
+            *h = output;
+            return;
+        }
+
+        let input_h = *h;
+        let input_m = *m;
+        let input_t = *t;
         let mut state = zkvm_blake2f_state {
             data: unsafe { transmute::<[u64; 8], [u8; 64]>(*h) },
         };
@@ -64,6 +121,14 @@ impl Crypto for ZkVMInterfaceCrypto {
         let ret = unsafe { zkvm_interface::zkvm_blake2f(rounds, &mut state, &m, &t, f as u8) };
         assert_eq!(ret, 0, "blake2f failed");
         *h = unsafe { transmute::<[u8; 64], [u64; 8]>(state.data) };
+        *self.blake2_cache.lock() = Some(Blake2CacheEntry {
+            rounds,
+            h: input_h,
+            m: input_m,
+            t: input_t,
+            f,
+            output: *h,
+        });
     }
 
     #[inline]
@@ -77,6 +142,16 @@ impl Crypto for ZkVMInterfaceCrypto {
 
     #[inline]
     fn modexp(&self, base: &[u8], exp: &[u8], modulus: &[u8]) -> Result<Vec<u8>, PrecompileHalt> {
+        if let Some(output) = self
+            .modexp_cache
+            .lock()
+            .as_ref()
+            .filter(|entry| entry.matches(base, exp, modulus))
+            .map(|entry| entry.output.clone())
+        {
+            return Ok(output);
+        }
+
         let mut output = vec![0u8; modulus.len()];
         let ret = unsafe {
             zkvm_interface::zkvm_modexp(
@@ -89,9 +164,17 @@ impl Crypto for ZkVMInterfaceCrypto {
                 output.as_mut_ptr(),
             )
         };
-        (ret == 0)
-            .then_some(output)
-            .ok_or_else(|| PrecompileHalt::other("modexp failed"))
+        if ret != 0 {
+            return Err(PrecompileHalt::other("modexp failed"));
+        }
+
+        *self.modexp_cache.lock() = Some(ModexpCacheEntry {
+            base: base.to_vec(),
+            exp: exp.to_vec(),
+            modulus: modulus.to_vec(),
+            output: output.clone(),
+        });
+        Ok(output)
     }
 
     #[inline]


### PR DESCRIPTION
## Summary

Adds one-entry exact caches around repeated pure precompile calls in the Reth SP1 guest `zkvm_interface` crypto backend.

This PR only memoizes the immediately previous input/output pair for:

- `MODEXP`
- `BLAKE2F`

The caches preserve precompile semantics and use a no-std `spin::Mutex`, so the change stays compatible with guest builds.

## Benchmark

Article-compatible Osaka 10M full benchmark, SP1, Reth guest:

| Client | Total cycles |
| --- | ---: |
| Reth with broader experimental stack | `156,962,041,228` |
| Zilkworm article baseline | `159,156,117,864` |

| Ratio | Value |
| --- | ---: |
| `Zilkworm / Reth` | `1.014` |
| Output matches | `1077 / 1077` |

Focused deltas from this precompile-cache portion on the same benchmark branch:

| Scope | Delta |
| --- | ---: |
| `MODEXP` repeated-input cache | `-8,630,598,664` cycles |
| `BLAKE2F` repeated-input cache | `-3,357,118,537` cycles |
