### PR TITLE
feat: add zesu and R2 glasmterdam-devnet-7 fixtures

### DIFF
--- a/.github/scripts/fetch-elf-for-republish.sh
+++ b/.github/scripts/fetch-elf-for-republish.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 #
-# Fetches the prebuilt guest ELF for <guest> listed in artifact-registry.json,
-# verifies its sha256, and writes OUTPUT_DIR/stateless-validator-<guest>.elf.
+# Fetches the prebuilt guest ELF listed in artifact-registry.json, verifies its
+# sha256, and writes OUTPUT_DIR/stateless-validator-<stateless-validator>-<zkvm>.elf.
 #
-# Usage: fetch-elf-for-republish.sh <el>-<zkvm>
+# Usage: fetch-elf-for-republish.sh <stateless-validator> <zkvm>
 #   REGISTRY    artifact-registry.json (default: artifact-registry.json)
 #   OUTPUT_DIR  output directory (default: output)
 
 set -euo pipefail
 
-GUEST="${1:?usage: fetch-elf-for-republish.sh <el>-<zkvm>}"
+NAME="${1:?usage: fetch-elf-for-republish.sh <stateless-validator> <zkvm>}"
+ZKVM="${2:?usage: fetch-elf-for-republish.sh <stateless-validator> <zkvm>}"
 REGISTRY="${REGISTRY:-artifact-registry.json}"
 OUTPUT_DIR="${OUTPUT_DIR:-output}"
 
-entry() { jq -r --arg g "$GUEST" ".stateless_validator_elf[\$g].$1 // empty" "$REGISTRY"; }
+entry() {
+    jq -r --arg name "$NAME" --arg zkvm "$ZKVM" --arg field "$1" \
+        '.stateless_validators[] | select(.name == $name)
+         | .elfs[] | select(.zkvm == $zkvm) | .[$field] // empty' "$REGISTRY"
+}
 
 WORKSPACE="$(mktemp -d)"
 trap 'rm -rf "$WORKSPACE"' EXIT
@@ -22,7 +27,7 @@ mkdir -p "$OUTPUT_DIR"
 curl -fsSL --proto '=https' --tlsv1.2 --retry 3 "$(entry url)" -o "$WORKSPACE/download"
 echo "$(entry sha256) $WORKSPACE/download" | sha256sum -c -
 
-OUT="$OUTPUT_DIR/stateless-validator-$GUEST.elf"
+OUT="$OUTPUT_DIR/stateless-validator-$NAME-$ZKVM.elf"
 mv "$WORKSPACE/download" "$OUT"
 
 echo "Prepared $OUT"

--- a/.github/scripts/release-body.py
+++ b/.github/scripts/release-body.py
@@ -9,28 +9,28 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from subprocess import DEVNULL, PIPE, STDOUT
+from subprocess import DEVNULL, PIPE
 
 ROOT = Path(__file__).resolve().parents[2]
 TARGET_DIR = ROOT / "target"
 
 REPOSITORY = "eth-act/ere-guests"
 GUEST_PREFIX = "stateless-validator-"
-COMPILED_ELS = ("ethrex", "reth")
+COMPILED_STATELESS_VALIDATORS = ("ethrex", "reth")
 ZKVMS = ("openvm", "sp1", "zisk")
 
 TABLE_HEADER = (
-    "| EL | EL Version | zkVM | zkVM Version | Target | ELF | Program VK |",
+    "| Stateless Validator | Version | zkVM | zkVM Version | Target | ELF | Program VK |",
     "| --- | --- | --- | --- | --- | --- | --- |",
 )
 
 
 @dataclass(frozen=True)
 class Guest:
-    """A guest program keyed by execution layer and zkVM, with display versions."""
+    """A guest program keyed by stateless validator and zkVM, with display versions."""
 
-    el: str
-    el_version: str
+    stateless_validator: str
+    version: str
     zkvm: str
     zkvm_version: str
     source_url: str | None = None
@@ -84,8 +84,8 @@ def read_catalog_versions(package: str, version_file: str) -> dict[str, str]:
     return {kind.lower(): version for kind, version in versions}
 
 
-def read_compiled_el_versions() -> dict[str, str]:
-    """Returns EL versions parsed from the `stateless-validator-catalog` build script."""
+def read_compiled_versions() -> dict[str, str]:
+    """Returns versions parsed from the `stateless-validator-catalog` build script."""
     return read_catalog_versions("stateless-validator-catalog", "version_impl.rs")
 
 
@@ -110,8 +110,8 @@ def read_elf_word_size(elf_path: Path) -> int:
 
 def render_row(guest: Guest, artifacts_dir: Path, release_url: str) -> str | None:
     """Renders `guest` as a Markdown table row, or None when its ELF or VK is absent."""
-    elf = f"{GUEST_PREFIX}{guest.el}-{guest.zkvm}.elf"
-    vk = f"{GUEST_PREFIX}{guest.el}-{guest.zkvm}.vk"
+    elf = f"{GUEST_PREFIX}{guest.stateless_validator}-{guest.zkvm}.elf"
+    vk = f"{GUEST_PREFIX}{guest.stateless_validator}-{guest.zkvm}.vk"
     elf_path = artifacts_dir / elf
     vk_path = artifacts_dir / vk
     if not (elf_path.is_file() and vk_path.is_file()):
@@ -122,18 +122,18 @@ def render_row(guest: Guest, artifacts_dir: Path, release_url: str) -> str | Non
     if guest.source_url:
         elf_cell += f" / [Source]({guest.source_url})"
     return (
-        f"| `{guest.el}` | `{guest.el_version}` "
+        f"| `{guest.stateless_validator}` | `{guest.version}` "
         f"| `{guest.zkvm}` | `{guest.zkvm_version}` "
         f"| `{target}` | {elf_cell} | [Link]({release_url}/{vk}) |"
     )
 
 
 def compiled_guests(zkvm_versions: dict[str, str]) -> list[Guest]:
-    """Returns the COMPILED_ELS x ZKVMS guests, with versions from the build scripts."""
-    el_versions = read_compiled_el_versions()
+    """Returns the COMPILED_STATELESS_VALIDATORS x ZKVMS guests, versioned by the build scripts."""
+    versions = read_compiled_versions()
     return [
-        Guest(el, el_versions[el], zkvm, zkvm_versions[zkvm])
-        for el in COMPILED_ELS
+        Guest(name, versions[name], zkvm, zkvm_versions[zkvm])
+        for name in COMPILED_STATELESS_VALIDATORS
         for zkvm in ZKVMS
     ]
 
@@ -141,14 +141,20 @@ def compiled_guests(zkvm_versions: dict[str, str]) -> list[Guest]:
 def republished_guests(
     artifact_registry: Path, zkvm_versions: dict[str, str]
 ) -> list[Guest]:
-    """Returns the registry guests, ordered by key, with zkVM versions from the SDK."""
-    registry = json.loads(artifact_registry.read_text())["stateless_validator_elf"]
+    """Returns the registry guests, ordered by name then zkVM, with zkVM versions from the SDK."""
+    registry = json.loads(artifact_registry.read_text())["stateless_validators"]
     guests = []
-    for key, entry in sorted(registry.items()):
-        el, zkvm = key.rsplit("-", 1)
-        guests.append(
-            Guest(el, entry["el_version"], zkvm, zkvm_versions[zkvm], entry["url"])
-        )
+    for validator in sorted(registry, key=lambda entry: entry["name"]):
+        for elf in sorted(validator["elfs"], key=lambda entry: entry["zkvm"]):
+            guests.append(
+                Guest(
+                    validator["name"],
+                    validator["version"],
+                    elf["zkvm"],
+                    zkvm_versions[elf["zkvm"]],
+                    elf["url"],
+                )
+            )
     return guests
 
 
@@ -175,7 +181,7 @@ def republished_rows(
         row = render_row(guest, artifacts_dir, release_url)
         if row is None:
             raise RuntimeError(
-                f"republished guest {GUEST_PREFIX}{guest.el}-{guest.zkvm}.elf is missing"
+                f"republished guest {GUEST_PREFIX}{guest.stateless_validator}-{guest.zkvm}.elf is missing"
             )
         rows.append(row)
     return rows

--- a/.github/scripts/release-body.py
+++ b/.github/scripts/release-body.py
@@ -62,12 +62,15 @@ def run_command(
 
 
 def read_ere_version() -> str:
-    """Returns the Ere version pinned by git tag in the workspace Cargo.toml."""
+    """Returns the Ere version pinned by git tag or revision in the workspace Cargo.toml."""
     cargo_toml = (ROOT / "Cargo.toml").read_text()
-    match = re.search(r'eth-act/ere"[^}]*?\btag\s*=\s*"(v[^"]+)"', cargo_toml)
-    if not match:
-        raise RuntimeError('no `eth-act/ere` git `tag = "vX.Y.Z"` found in Cargo.toml')
-    return match.group(1)
+    tag = re.search(r'eth-act/ere"[^}]*?\btag\s*=\s*"v([^"]+)"', cargo_toml)
+    if tag:
+        return tag.group(1)
+    rev = re.search(r'eth-act/ere"[^}]*?\brev\s*=\s*"([0-9a-f]{7,40})"', cargo_toml)
+    if rev:
+        return rev.group(1)[:7]
+    raise RuntimeError("no `eth-act/ere` git `tag` or `rev` found in Cargo.toml")
 
 
 def read_catalog_versions(package: str, version_file: str) -> dict[str, str]:

--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -18,14 +18,14 @@ permissions:
 
 jobs:
   compile:
-    name: Compile stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}
+    name: Compile stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}
     runs-on: ubuntu-latest
     outputs:
       ere_tag: ${{ steps.get_ere_tag.outputs.ere_tag }}
     strategy:
       fail-fast: false
       matrix:
-        el:
+        stateless_validator:
           - ethrex
           - reth
         zkvm:
@@ -33,7 +33,7 @@ jobs:
           - sp1
           - zisk
         include:
-          - el: ethrex
+          - stateless_validator: ethrex
             zkvm: zisk
             ere_profile: ethrex
     steps:
@@ -66,9 +66,9 @@ jobs:
             -v $PWD/output:/output \
             ghcr.io/eth-act/ere/ere-compiler-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }} \
             --compiler-kind rust-customized \
-            --guest-dir /ere-guests/bin/stateless-validator-${{ matrix.el }}/${{ matrix.zkvm }} \
+            --guest-dir /ere-guests/bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }} \
             --output-dir /output \
-            --elf-name stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.elf
+            --elf-name stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.elf
 
       - name: Compile ZisK guest with feature cycle-scope enabled
         if: ${{ matrix.zkvm == 'zisk' }}
@@ -81,9 +81,9 @@ jobs:
             -v $PWD/output:/output \
             ghcr.io/eth-act/ere/ere-compiler-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }} \
             --compiler-kind rust-customized \
-            --guest-dir /ere-guests/bin/stateless-validator-${{ matrix.el }}/${{ matrix.zkvm }} \
+            --guest-dir /ere-guests/bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }} \
             --output-dir /output \
-            --elf-name stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}-profiling.elf \
+            --elf-name stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}-profiling.elf \
             -- \
             --features cycle-scope
 
@@ -93,17 +93,17 @@ jobs:
             -e RUST_LOG=info \
             -v $PWD/output:/output \
             ghcr.io/eth-act/ere/ere-server-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }} \
-            --elf-path /output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.elf \
+            --elf-path /output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.elf \
             keygen \
-            --program-vk-path /output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.vk
+            --program-vk-path /output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.vk
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}
+          name: stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}
           path: |
-            output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}*.elf
-            output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.vk
+            output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}*.elf
+            output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.vk
           if-no-files-found: error
 
   republish-setup:
@@ -118,12 +118,12 @@ jobs:
       - name: Build matrix from artifact-registry.json
         id: set-matrix
         run: |
-          MATRIX=$(jq -c '{ include: [.stateless_validator_elf | keys[] | (. / "-") as $p | { el: ($p[:-1] | join("-")), zkvm: $p[-1] }] }' artifact-registry.json)
+          MATRIX=$(jq -c '{ include: [.stateless_validators[] as $sv | $sv.elfs[] | { stateless_validator: $sv.name, zkvm: .zkvm }] }' artifact-registry.json)
           echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
           echo "Matrix: ${MATRIX}"
 
   republish:
-    name: Republish stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}
+    name: Republish stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}
     needs: republish-setup
     if: fromJson(needs.republish-setup.outputs.matrix).include[0] != null
     runs-on: ubuntu-latest
@@ -150,7 +150,7 @@ jobs:
           docker pull ghcr.io/eth-act/ere/ere-server-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }}
 
       - name: Download ELF
-        run: bash .github/scripts/fetch-elf-for-republish.sh ${{ matrix.el }}-${{ matrix.zkvm }}
+        run: bash .github/scripts/fetch-elf-for-republish.sh ${{ matrix.stateless_validator }} ${{ matrix.zkvm }}
 
       - name: Generate program VK
         run: |
@@ -158,17 +158,17 @@ jobs:
             -e RUST_LOG=info \
             -v $PWD/output:/output \
             ghcr.io/eth-act/ere/ere-server-${{ matrix.zkvm }}:${{ steps.get_ere_tag.outputs.ere_tag }} \
-            --elf-path /output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.elf \
+            --elf-path /output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.elf \
             keygen \
-            --program-vk-path /output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.vk
+            --program-vk-path /output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.vk
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}
+          name: stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}
           path: |
-            output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}*.elf
-            output/stateless-validator-${{ matrix.el }}-${{ matrix.zkvm }}.vk
+            output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}*.elf
+            output/stateless-validator-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}.vk
           if-no-files-found: error
 
   check-git-tag:
@@ -194,7 +194,6 @@ jobs:
   update-release-with-artifacts:
     name: Update release with artifacts
     needs: check-git-tag
-    if: needs.check-git-tag.outputs.exists == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -257,11 +256,13 @@ jobs:
           ls -R artifacts
 
       - name: Upload artifacts to release
+        if: needs.check-git-tag.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload --repo "${{ github.repository }}" "${{ needs.check-git-tag.outputs.tag }}" artifacts/* --clobber
 
       - name: Append artifact info to release notes
+        if: needs.check-git-tag.outputs.exists == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/integration-test-devnet.yml
+++ b/.github/workflows/integration-test-devnet.yml
@@ -71,7 +71,6 @@ jobs:
         run: echo "ERE_PROFILE=$ERE_PROFILE" >> "$GITHUB_ENV"
 
       - name: Run zkVM execution of the latest devnet blocks
-        shell: bash
         env:
           RUST_LOG: info,ere_server=error
           ERE_IMAGE_REGISTRY: ghcr.io/eth-act/ere
@@ -79,7 +78,8 @@ jobs:
         run: |
           cargo run --release --package stateless-validator-test --bin zkvm_execution_devnet -- \
             --zkvm ${{ matrix.zkvm }} \
-            --stateless-validator ${{ matrix.stateless_validator }} | tee failures.txt
+            --stateless-validator ${{ matrix.stateless_validator }} \
+            --output failures.txt
           {
             echo "### ${{ matrix.stateless_validator }} on ${{ matrix.zkvm }}"
             echo '```'

--- a/.github/workflows/integration-test-devnet.yml
+++ b/.github/workflows/integration-test-devnet.yml
@@ -1,0 +1,97 @@
+name: Integration test devnet
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test_zkvm_execution_devnet:
+    name: ${{ matrix.stateless_validator }} on ${{ matrix.zkvm }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        stateless_validator:
+          - ethrex
+          - reth
+        zkvm:
+          - openvm
+          - sp1
+          - zisk
+        include:
+          - { zkvm: zisk, external: true, stateless_validator: zesu }
+          - { zkvm: zisk, stateless_validator: ethrex, ere_profile: ethrex }
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Free up disk space
+        if: matrix.zkvm == 'zisk'
+        run: bash .github/scripts/free-up-disk-space.sh
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache bin target
+        if: matrix.external != true
+        uses: actions/cache@v4
+        with:
+          path: bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }}/target
+          key: ${{ format('{0}-bin-{1}-{2}-{3}', runner.os, matrix.stateless_validator, matrix.zkvm, hashFiles(format('bin/stateless-validator-{0}/{1}/Cargo.lock', matrix.stateless_validator, matrix.zkvm))) }}
+          restore-keys: |
+            ${{ runner.os }}-bin-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}-
+
+      - name: Enable Ere profile
+        if: matrix.ere_profile != ''
+        env:
+          ERE_PROFILE: ${{ matrix.ere_profile }}
+        run: echo "ERE_PROFILE=$ERE_PROFILE" >> "$GITHUB_ENV"
+
+      - name: Run zkVM execution of the latest devnet blocks
+        shell: bash
+        env:
+          RUST_LOG: info,ere_server=error
+          ERE_IMAGE_REGISTRY: ghcr.io/eth-act/ere
+          OPENVM_RUST_TOOLCHAIN: nightly-2026-01-18
+        run: |
+          cargo run --release --package stateless-validator-test --bin zkvm_execution_devnet -- \
+            --zkvm ${{ matrix.zkvm }} \
+            --stateless-validator ${{ matrix.stateless_validator }} | tee failures.txt
+          {
+            echo "### ${{ matrix.stateless_validator }} on ${{ matrix.zkvm }}"
+            echo '```'
+            cat failures.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Chown
+        if: matrix.external != true
+        run: |
+          sudo chown -R $(id -u):$(id -g) bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }}/target || true
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,12 +15,12 @@ env:
 
 jobs:
   test_zkvm_execution:
-    name: ${{ matrix.guest }} on ${{ matrix.zkvm }}
+    name: ${{ matrix.stateless_validator }} on ${{ matrix.zkvm }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        stateless_validator:
           - ethrex
           - reth
         zkvm:
@@ -28,8 +28,8 @@ jobs:
           - sp1
           - zisk
         include:
-          - { zkvm: zisk, external: true, guest: zesu }
-          - { zkvm: zisk, guest: ethrex, ere_profile: ethrex }
+          - { zkvm: zisk, external: true, stateless_validator: zesu }
+          - { zkvm: zisk, stateless_validator: ethrex, ere_profile: ethrex }
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -64,10 +64,10 @@ jobs:
         if: matrix.external != true
         uses: actions/cache@v4
         with:
-          path: bin/stateless-validator-${{ matrix.guest }}/${{ matrix.zkvm }}/target
-          key: ${{ format('{0}-bin-{1}-{2}-{3}', runner.os, matrix.guest, matrix.zkvm, hashFiles(format('bin/stateless-validator-{0}/{1}/Cargo.lock', matrix.guest, matrix.zkvm))) }}
+          path: bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }}/target
+          key: ${{ format('{0}-bin-{1}-{2}-{3}', runner.os, matrix.stateless_validator, matrix.zkvm, hashFiles(format('bin/stateless-validator-{0}/{1}/Cargo.lock', matrix.stateless_validator, matrix.zkvm))) }}
           restore-keys: |
-            ${{ runner.os }}-bin-${{ matrix.guest }}-${{ matrix.zkvm }}-
+            ${{ runner.os }}-bin-${{ matrix.stateless_validator }}-${{ matrix.zkvm }}-
 
       - name: Set rayon threads
         if: matrix.threads != ''
@@ -87,7 +87,7 @@ jobs:
           ERE_IMAGE_REGISTRY: ghcr.io/eth-act/ere
           OPENVM_RUST_TOOLCHAIN: nightly-2026-01-18
         run: |
-          cargo test --release --package stateless-validator-test --test zkvm_execution -- ${{ matrix.guest }}_${{ matrix.zkvm }}_rpc --test-threads=1
+          cargo test --release --package stateless-validator-test --test zkvm_execution -- ${{ matrix.stateless_validator }}_${{ matrix.zkvm }}_rpc --test-threads=1
 
       - name: Test zkVM execution (EEST fixtures)
         env:
@@ -95,24 +95,24 @@ jobs:
           ERE_IMAGE_REGISTRY: ghcr.io/eth-act/ere
           OPENVM_RUST_TOOLCHAIN: nightly-2026-01-18
         run: |
-          cargo test --release --package stateless-validator-test --test zkvm_execution -- ${{ matrix.guest }}_${{ matrix.zkvm }}_eest --test-threads=1
+          cargo test --release --package stateless-validator-test --test zkvm_execution -- ${{ matrix.stateless_validator }}_${{ matrix.zkvm }}_eest --test-threads=1
 
       - name: Chown
         if: matrix.external != true
         run: |
-          sudo chown -R $(id -u):$(id -g) bin/stateless-validator-${{ matrix.guest }}/${{ matrix.zkvm }}/target || true
+          sudo chown -R $(id -u):$(id -g) bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }}/target || true
 
       - name: Run sccache stat for check
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
 
   test_host_execution:
-    name: ${{ matrix.guest }} on host
+    name: ${{ matrix.stateless_validator }} on host
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        guest:
+        stateless_validator:
           - ethrex
           - reth
     steps:
@@ -146,7 +146,7 @@ jobs:
           RUST_LOG: info
           CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: true
         run: |
-          cargo test --release --package stateless-validator-${{ matrix.guest }} --features host --test host_execution -- --test-threads=1
+          cargo test --release --package stateless-validator-${{ matrix.stateless_validator }} --features host --test host_execution -- --test-threads=1
 
       - name: Run sccache stat for check
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-catalog"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -1634,12 +1634,12 @@ dependencies = [
 [[package]]
 name = "ere-codec"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-compiler-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "serde",
 ]
@@ -1647,7 +1647,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -1664,12 +1664,12 @@ dependencies = [
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-prover-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -1686,7 +1686,7 @@ dependencies = [
 [[package]]
 name = "ere-server-api"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "prost",
  "serde",
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "ere-server-client"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "ere-util-build"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "cargo_metadata",
 ]
@@ -1716,7 +1716,7 @@ dependencies = [
 [[package]]
 name = "ere-util-tokio"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "tokio",
 ]
@@ -1724,7 +1724,7 @@ dependencies = [
 [[package]]
 name = "ere-verifier-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "auto_impl",
  "ere-codec",
@@ -5764,6 +5764,7 @@ version = "0.13.0"
 dependencies = [
  "ere-util-build",
  "serde",
+ "serde_json",
  "strum 0.28.0",
 ]
 
@@ -5860,6 +5861,7 @@ version = "0.13.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "clap",
  "const-hex",
  "dashmap",
  "ere-dockerized",
@@ -5871,6 +5873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "stateless-validator-catalog",
  "stateless-validator-common",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,9 +110,9 @@ bls12_381 = { git = "https://github.com/zkcrypto/bls12_381", rev = "6bb96951d5c2
 zkvm-interface = { git = "https://github.com/eth-act/zkvm-standards", rev = "282cd356c3a0498416bb0619f9c8a347ce9933fb" }
 
 # ere
-ere-dockerized = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
-ere-platform-core = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
-ere-util-build = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b" }
+ere-util-build = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b" }
 
 # local
 stateless-validator-catalog = { path = "crates/stateless-validator-catalog" }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains guest programs and libraries designed to run on zkVM pl
 
 Located in `crates/`, these provide reusable functionality for guest programs and host:
 
-- [`stateless-validator-catalog`](crates/stateless-validator-catalog) - Catalog of stateless validator kinds and their execution client versions
+- [`stateless-validator-catalog`](crates/stateless-validator-catalog) - Catalog of stateless validator kinds and their versions
 - [`stateless-validator-common`](crates/stateless-validator-common) - Canonical SSZ stateless input and output types shared by both validators
 - [`stateless-validator-ethrex`](crates/stateless-validator-ethrex) - Stateless validation using Ethrex
 - [`stateless-validator-reth`](crates/stateless-validator-reth) - Stateless validation using Reth

--- a/artifact-registry.json
+++ b/artifact-registry.json
@@ -1,5 +1,15 @@
 {
-    "stateless_validator_elf": {},
-    "stateless_validator_static_library": {},
-    "zkvm_static_library": {}
+    "stateless_validators": [
+        {
+            "name": "zesu",
+            "version": "glamsterdam-devnet-7.2",
+            "elfs": [
+                {
+                    "zkvm": "zisk",
+                    "url": "https://github.com/Consensys/zesu-zkvm/releases/download/glamsterdam-devnet-7.2/stateless-validator-zesu-zisk.elf",
+                    "sha256": "7c30f33339eecf05f47c104b1d18e74d5ce4ed12c8596cf63002c33b25c6f81f"
+                }
+            ]
+        }
+    ]
 }

--- a/bin/stateless-validator-ethrex/openvm/Cargo.lock
+++ b/bin/stateless-validator-ethrex/openvm/Cargo.lock
@@ -686,12 +686,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-platform-openvm"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/stateless-validator-ethrex/openvm/Cargo.toml
+++ b/bin/stateless-validator-ethrex/openvm/Cargo.toml
@@ -14,7 +14,7 @@ openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", tag =
 openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v2.0.0" }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -821,12 +821,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-platform-sp1"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-platform-core",
  "libzkevm",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.toml
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b" }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -774,12 +774,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-platform-zisk"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-platform-core",
  "ziskos",

--- a/bin/stateless-validator-ethrex/zisk/Cargo.toml
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010", default-features = false, features = ["inputcpy"] }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b", default-features = false, features = ["inputcpy"] }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -1110,12 +1110,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-platform-openvm"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -37,7 +37,7 @@ openvm-kzg = { git = "https://github.com/axiom-crypto/openvm-eth", rev = "aa8bbe
 aurora-engine-modexp = { version = "1.2.0", default-features = false }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -1229,12 +1229,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-platform-sp1"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-platform-core",
  "libzkevm",

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -13,7 +13,7 @@ alloy-primitives = { version = "1.6.0", default-features = false, features = [
 ] }
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", features = [

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -1141,12 +1141,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 
 [[package]]
 name = "ere-platform-zisk"
 version = "0.13.0"
-source = "git+https://github.com/eth-act/ere?rev=58ca85beaee2fa8acd31dbf33b90bb765aac9010#58ca85beaee2fa8acd31dbf33b90bb765aac9010"
+source = "git+https://github.com/eth-act/ere?rev=a25f1aed9664c3b63e73ef05360090a4c41da31b#a25f1aed9664c3b63e73ef05360090a4c41da31b"
 dependencies = [
  "ere-platform-core",
  "ziskos",

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -16,7 +16,7 @@ alloy-primitives = { version = "1.6.0", default-features = false, features = [
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "58ca85beaee2fa8acd31dbf33b90bb765aac9010", default-features = false, features = [
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "a25f1aed9664c3b63e73ef05360090a4c41da31b", default-features = false, features = [
     "inputcpy",
 ] }
 

--- a/crates/stateless-validator-catalog/Cargo.toml
+++ b/crates/stateless-validator-catalog/Cargo.toml
@@ -14,3 +14,5 @@ strum = { workspace = true, features = ["derive"] }
 
 [build-dependencies]
 ere-util-build.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/crates/stateless-validator-catalog/build.rs
+++ b/crates/stateless-validator-catalog/build.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let version_impl = format!(
         r#"impl crate::StatelessValidatorKind {{
-    /// Returns the execution client version.
+    /// Returns the stateless validator version.
     pub const fn version(&self) -> &'static str {{
         match self {{
             Self::Ethrex => "{ethrex_version}",

--- a/crates/stateless-validator-catalog/build.rs
+++ b/crates/stateless-validator-catalog/build.rs
@@ -2,11 +2,13 @@
 
 use std::{env, fs, path::Path};
 
-use ere_util_build::{cargo_lock_path, detect_dep_version};
+use ere_util_build::{cargo_lock_path, detect_dep_version, workspace};
+use serde::Deserialize;
 
 fn main() {
     let ethrex_version = detect_dep_version("stateless-validator-ethrex", "ethrex-guest-program");
     let reth_version = detect_dep_version("stateless-validator-reth", "reth-chainspec");
+    let zesu_version = registry_version("zesu");
 
     let version_impl = format!(
         r#"impl crate::StatelessValidatorKind {{
@@ -15,6 +17,7 @@ fn main() {
         match self {{
             Self::Ethrex => "{ethrex_version}",
             Self::Reth => "{reth_version}",
+            Self::Zesu => "{zesu_version}",
         }}
     }}
 }}"#,
@@ -27,4 +30,32 @@ fn main() {
     if let Some(cargo_lock) = cargo_lock_path() {
         println!("cargo:rerun-if-changed={}", cargo_lock.display());
     }
+}
+
+/// Resolves the version of the `name` stateless validator from `artifact-registry.json`.
+fn registry_version(name: &str) -> String {
+    #[derive(Deserialize)]
+    struct ArtifactRegistry {
+        stateless_validators: Vec<StatelessValidator>,
+    }
+
+    #[derive(Deserialize)]
+    struct StatelessValidator {
+        name: String,
+        version: String,
+    }
+
+    let registry_path = workspace()
+        .expect("workspace should be found")
+        .join("artifact-registry.json");
+    println!("cargo:rerun-if-changed={}", registry_path.display());
+
+    let registry =
+        serde_json::from_slice::<ArtifactRegistry>(&fs::read(&registry_path).unwrap()).unwrap();
+    registry
+        .stateless_validators
+        .into_iter()
+        .find(|validator| validator.name == name)
+        .unwrap_or_else(|| panic!("`{name}` not found in artifact-registry.json"))
+        .version
 }

--- a/crates/stateless-validator-catalog/src/lib.rs
+++ b/crates/stateless-validator-catalog/src/lib.rs
@@ -47,6 +47,8 @@ pub enum StatelessValidatorKind {
     Ethrex,
     /// Reth stateless validator.
     Reth,
+    /// Zesu stateless validator.
+    Zesu,
 }
 
 impl StatelessValidatorKind {
@@ -131,6 +133,7 @@ mod tests {
         for (ss, kind) in [
             (["ethrex", "Ethrex"], StatelessValidatorKind::Ethrex),
             (["reth", "Reth"], StatelessValidatorKind::Reth),
+            (["zesu", "Zesu"], StatelessValidatorKind::Zesu),
         ] {
             ss.iter().for_each(|s| assert_eq!(s.parse(), Ok(kind)));
             assert_eq!(kind.as_str(), ss[0]);
@@ -143,7 +146,8 @@ mod tests {
         );
         assert_eq!(
             ParseError::from("xxx").to_string(),
-            "Unsupported stateless validator kind `xxx`, expect one of [ethrex, reth]".to_string()
+            "Unsupported stateless validator kind `xxx`, expect one of [ethrex, reth, zesu]"
+                .to_string()
         );
     }
 }

--- a/crates/stateless-validator-ethrex/Cargo.toml
+++ b/crates/stateless-validator-ethrex/Cargo.toml
@@ -43,6 +43,10 @@ paste.workspace = true
 ere-dockerized.workspace = true
 stateless-validator-test.workspace = true
 
+[[test]]
+name = "host_execution"
+required-features = ["host"]
+
 [features]
 # guest
 default = ["std"]

--- a/crates/stateless-validator-ethrex/tests/host_execution.rs
+++ b/crates/stateless-validator-ethrex/tests/host_execution.rs
@@ -4,4 +4,5 @@ use stateless_validator_ethrex::guest::run_stateless_guest;
 use stateless_validator_test::declare_test_host_execution;
 
 declare_test_host_execution!(RpcBpo2, run_stateless_guest);
+declare_test_host_execution!(RpcGlamsterdamDevnet7, run_stateless_guest);
 declare_test_host_execution!(EestGlamsterdamDevnet7, run_stateless_guest);

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -48,6 +48,10 @@ paste.workspace = true
 ere-dockerized.workspace = true
 stateless-validator-test.workspace = true
 
+[[test]]
+name = "host_execution"
+required-features = ["host"]
+
 [features]
 # guest
 default = ["std"]

--- a/crates/stateless-validator-reth/tests/host_execution.rs
+++ b/crates/stateless-validator-reth/tests/host_execution.rs
@@ -5,6 +5,9 @@ use stateless_validator_test::declare_test_host_execution;
 
 declare_test_host_execution!(RpcBpo2, run_stateless_guest);
 // NOTE:
+// - 1 EIP-8025 (in-block created-code resolution)
+declare_test_host_execution!(RpcGlamsterdamDevnet7, run_stateless_guest, failures = 1);
+// NOTE:
 // - 12 EIP-7610
 //    - test_init_collision_create_tx
 //    - test_init_collision_create_opcode

--- a/crates/stateless-validator-test/Cargo.toml
+++ b/crates/stateless-validator-test/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
 dashmap.workspace = true
 flate2.workspace = true
 const-hex.workspace = true
@@ -33,6 +34,7 @@ ere-dockerized.workspace = true
 ere-platform-core.workspace = true
 
 # local
+stateless-validator-catalog.workspace = true
 stateless-validator-common = { workspace = true, features = ["host"] }
 
 [dev-dependencies]

--- a/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
+++ b/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
@@ -1,0 +1,110 @@
+//! Runs the latest blocks published in the devnet catalog through a stateless
+//! validator guest program in a zkVM, reporting the failures on stdout.
+//!
+//! Run with env `ERE_IMAGE_REGISTRY=ghcr.io/eth-act/ere` to use the pre-built
+//! image as the executor.
+//!
+//! Run with env `OPENVM_RUST_TOOLCHAIN=nightly-2026-01-18` for OpenVM to
+//! compile Reth guest.
+
+use clap::Parser;
+use ere_dockerized::zkVMKind;
+use serde::Deserialize;
+use stateless_validator_catalog::StatelessValidatorKind;
+use stateless_validator_test::{
+    execution::{ExecutionFailures, init_tracing, zkvm::run_stateless_validator_execution},
+    fixture::{R2_FIXTURES_BASE_URL, StatelessValidatorFixture, archive_fixtures},
+};
+use tracing::info;
+
+/// Subdirectory under `<crate>/fixtures/` caching the devnet batch archives.
+const DEVNET_FIXTURES_DIR: &str = "rpc-glamsterdam-devnet-7";
+
+/// CLI options for the devnet zkVM execution runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Parser)]
+#[command(
+    name = "zkvm_execution_devnet",
+    about = "Run the latest devnet blocks through a stateless validator guest in a zkVM.",
+    long_about = None,
+    arg_required_else_help = true
+)]
+struct Cli {
+    /// zkVM to execute the guest on.
+    #[arg(long)]
+    zkvm: zkVMKind,
+    /// Stateless validator guest to execute.
+    #[arg(long)]
+    stateless_validator: StatelessValidatorKind,
+    /// Number of latest published block artifacts to run.
+    #[arg(long, default_value_t = 100)]
+    blocks: usize,
+}
+
+fn main() {
+    let cli = Cli::parse();
+    init_tracing();
+    let fixtures = latest_devnet_fixtures(cli.blocks);
+    let failures = run_stateless_validator_execution(cli.stateless_validator, cli.zkvm, fixtures);
+    print!("{}", ExecutionFailures(&failures));
+}
+
+/// Returns the fixtures of the latest `count` block artifacts published in the
+/// devnet catalog, downloading and unpacking the batch archives covering them
+/// into the local cache on first use.
+fn latest_devnet_fixtures(count: usize) -> Vec<StatelessValidatorFixture> {
+    let mut fixtures = latest_devnet_batches(count)
+        .into_iter()
+        .flat_map(|batch| {
+            archive_fixtures(
+                &format!(
+                    "{DEVNET_FIXTURES_DIR}/{}-{}",
+                    batch.batch_start_block, batch.batch_end_block
+                ),
+                &format!("{R2_FIXTURES_BASE_URL}/{}", batch.path),
+                "blockchain_tests",
+            )
+        })
+        .collect::<Vec<_>>();
+    fixtures.drain(..fixtures.len().saturating_sub(count));
+    fixtures
+}
+
+/// Returns the latest batches of the devnet catalog covering at least `count`
+/// block artifacts, in ascending block order.
+fn latest_devnet_batches(count: usize) -> Vec<DevnetBatch> {
+    let url = format!("{R2_FIXTURES_BASE_URL}/batches.jsonl");
+    info!("Downloading devnet batch index {url}");
+    let index = reqwest::blocking::get(&url)
+        .unwrap()
+        .error_for_status()
+        .unwrap()
+        .text()
+        .unwrap();
+
+    let mut batches = index
+        .lines()
+        .map(|line| serde_json::from_str::<DevnetBatch>(line).unwrap())
+        .collect::<Vec<_>>();
+    let take = (batches
+        .iter()
+        .rev()
+        .scan(0, |artifacts, batch| {
+            *artifacts += batch.artifact_count;
+            Some(*artifacts)
+        })
+        .take_while(|artifacts| *artifacts < count)
+        .count()
+        + 1)
+    .min(batches.len());
+    batches.split_off(batches.len() - take)
+}
+
+/// Wire shape of a batch entry in the devnet catalog's `batches.jsonl`.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DevnetBatch {
+    batch_start_block: u64,
+    batch_end_block: u64,
+    artifact_count: usize,
+    path: String,
+}

--- a/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
+++ b/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
@@ -12,12 +12,11 @@ use ere_dockerized::zkVMKind;
 use serde::Deserialize;
 use stateless_validator_catalog::StatelessValidatorKind;
 use stateless_validator_test::{
-    execution::{ExecutionFailures, init_tracing, zkvm::run_stateless_validator_execution},
+    execution::{ExecutionFailures, zkvm::run_stateless_validator_execution},
     fixture::{R2_FIXTURES_BASE_URL, StatelessValidatorFixture, archive_fixtures},
 };
-use tracing::info;
 
-/// Subdirectory under `<crate>/fixtures/` caching the devnet batch archives.
+/// Subdirectory under `<crate>/fixtures/` holding the unpacked devnet batches.
 const DEVNET_FIXTURES_DIR: &str = "rpc-glamsterdam-devnet-7";
 
 /// CLI options for the devnet zkVM execution runner.
@@ -42,7 +41,6 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
-    init_tracing();
     let fixtures = latest_devnet_fixtures(cli.blocks);
     let failures = run_stateless_validator_execution(cli.stateless_validator, cli.zkvm, fixtures);
     print!("{}", ExecutionFailures(&failures));
@@ -70,10 +68,10 @@ fn latest_devnet_fixtures(count: usize) -> Vec<StatelessValidatorFixture> {
 }
 
 /// Returns the latest batches of the devnet catalog covering at least `count`
-/// block artifacts, in ascending block order.
+/// block artifacts, keeping the order of `batches.jsonl`.
 fn latest_devnet_batches(count: usize) -> Vec<DevnetBatch> {
     let url = format!("{R2_FIXTURES_BASE_URL}/batches.jsonl");
-    info!("Downloading devnet batch index {url}");
+    println!("Downloading devnet batch index {url}");
     let index = reqwest::blocking::get(&url)
         .unwrap()
         .error_for_status()

--- a/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
+++ b/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
@@ -1,11 +1,13 @@
 //! Runs the latest blocks published in the devnet catalog through a stateless
-//! validator guest program in a zkVM, reporting the failures on stdout.
+//! validator guest program in a zkVM, reporting the failures.
 //!
 //! Run with env `ERE_IMAGE_REGISTRY=ghcr.io/eth-act/ere` to use the pre-built
 //! image as the executor.
 //!
 //! Run with env `OPENVM_RUST_TOOLCHAIN=nightly-2026-01-18` for OpenVM to
 //! compile Reth guest.
+
+use std::{fs, path::PathBuf};
 
 use clap::Parser;
 use ere_dockerized::zkVMKind;
@@ -20,7 +22,7 @@ use stateless_validator_test::{
 const DEVNET_FIXTURES_DIR: &str = "rpc-glamsterdam-devnet-7";
 
 /// CLI options for the devnet zkVM execution runner.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Parser)]
+#[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(
     name = "zkvm_execution_devnet",
     about = "Run the latest devnet blocks through a stateless validator guest in a zkVM.",
@@ -37,13 +39,18 @@ struct Cli {
     /// Number of latest published block artifacts to run.
     #[arg(long, default_value_t = 100)]
     blocks: usize,
+    /// Path to write the execution failures to.
+    #[arg(long)]
+    output: Option<PathBuf>,
 }
 
 fn main() {
     let cli = Cli::parse();
     let fixtures = latest_devnet_fixtures(cli.blocks);
     let failures = run_stateless_validator_execution(cli.stateless_validator, cli.zkvm, fixtures);
-    print!("{}", ExecutionFailures(&failures));
+    if let Some(output) = cli.output {
+        fs::write(output, ExecutionFailures(&failures).to_string()).unwrap();
+    }
 }
 
 /// Returns the fixtures of the latest `count` block artifacts published in the

--- a/crates/stateless-validator-test/src/execution.rs
+++ b/crates/stateless-validator-test/src/execution.rs
@@ -17,28 +17,6 @@ use crate::fixture::StatelessValidatorFixture;
 pub mod host;
 pub mod zkvm;
 
-/// A stateless validator guest program.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum GuestKind {
-    /// The ethrex guest.
-    Ethrex,
-    /// The reth guest.
-    Reth,
-    /// The zesu guest.
-    Zesu,
-}
-
-impl GuestKind {
-    /// Returns the guest name in lower-case.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Ethrex => "ethrex",
-            Self::Reth => "reth",
-            Self::Zesu => "zesu",
-        }
-    }
-}
-
 /// A fixture that failed to execute or match its expected output.
 #[derive(Debug, Clone)]
 pub struct ExecutionFailure {
@@ -63,17 +41,22 @@ impl Display for ExecutionFailures<'_> {
     }
 }
 
-/// Runs `execute` over every fixture in parallel, returning the failures.
-pub fn run_execution(
-    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
-    execute: &(impl Fn(Vec<u8>) -> anyhow::Result<Vec<u8>> + Sync),
-) -> Vec<ExecutionFailure> {
+/// Initializes the tracing subscriber, doing nothing after the first call.
+pub fn init_tracing() {
     static INIT_TRACING: Once = Once::new();
     INIT_TRACING.call_once(|| {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .try_init();
     });
+}
+
+/// Runs `execute` over every fixture in parallel, returning the failures.
+pub fn run_execution(
+    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
+    execute: &(impl Fn(Vec<u8>) -> anyhow::Result<Vec<u8>> + Sync),
+) -> Vec<ExecutionFailure> {
+    init_tracing();
 
     let fixtures = fixtures.into_iter().collect::<Vec<_>>();
     let total = fixtures.len();

--- a/crates/stateless-validator-test/src/execution.rs
+++ b/crates/stateless-validator-test/src/execution.rs
@@ -41,22 +41,17 @@ impl Display for ExecutionFailures<'_> {
     }
 }
 
-/// Initializes the tracing subscriber, doing nothing after the first call.
-pub fn init_tracing() {
+/// Runs `execute` over every fixture in parallel, returning the failures.
+pub fn run_execution(
+    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
+    execute: &(impl Fn(Vec<u8>) -> anyhow::Result<Vec<u8>> + Sync),
+) -> Vec<ExecutionFailure> {
     static INIT_TRACING: Once = Once::new();
     INIT_TRACING.call_once(|| {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .try_init();
     });
-}
-
-/// Runs `execute` over every fixture in parallel, returning the failures.
-pub fn run_execution(
-    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
-    execute: &(impl Fn(Vec<u8>) -> anyhow::Result<Vec<u8>> + Sync),
-) -> Vec<ExecutionFailure> {
-    init_tracing();
 
     let fixtures = fixtures.into_iter().collect::<Vec<_>>();
     let total = fixtures.len();

--- a/crates/stateless-validator-test/src/execution/zkvm.rs
+++ b/crates/stateless-validator-test/src/execution/zkvm.rs
@@ -8,10 +8,11 @@ use ere_dockerized::{
     ProverResource, zkVMKind,
 };
 use serde::Deserialize;
+use stateless_validator_catalog::StatelessValidatorKind;
 
 use crate::{
-    execution::{ExecutionFailure, GuestKind, run_execution},
-    fixture::{FixturePreset, preset_fixtures},
+    execution::{ExecutionFailure, run_execution},
+    fixture::StatelessValidatorFixture,
 };
 
 /// Returns path to the workspace root.
@@ -23,31 +24,43 @@ fn workspace() -> PathBuf {
 }
 
 /// Resolves and caches guest ELF by compiling (ethrex, reth) or downloading (zesu).
-pub fn resolve_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
-    static ELF: LazyLock<DashMap<(GuestKind, zkVMKind), Elf>> = LazyLock::new(DashMap::new);
-    ELF.entry((guest_kind, zkvm_kind))
-        .or_insert_with(|| match guest_kind {
-            GuestKind::Ethrex | GuestKind::Reth => compile_guest(guest_kind, zkvm_kind),
-            GuestKind::Zesu => download_guest(guest_kind, zkvm_kind),
+pub fn resolve_guest(stateless_validator_kind: StatelessValidatorKind, zkvm_kind: zkVMKind) -> Elf {
+    static ELF: LazyLock<DashMap<(StatelessValidatorKind, zkVMKind), Elf>> =
+        LazyLock::new(DashMap::new);
+    ELF.entry((stateless_validator_kind, zkvm_kind))
+        .or_insert_with(|| match stateless_validator_kind {
+            StatelessValidatorKind::Ethrex | StatelessValidatorKind::Reth => {
+                compile_guest(stateless_validator_kind, zkvm_kind)
+            }
+            StatelessValidatorKind::Zesu => download_guest(stateless_validator_kind, zkvm_kind),
         })
         .clone()
 }
 
 /// Compiles the guest program for `zkvm_kind` into an ELF.
-pub fn compile_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
-    assert!(matches!(guest_kind, GuestKind::Ethrex | GuestKind::Reth));
+pub fn compile_guest(stateless_validator_kind: StatelessValidatorKind, zkvm_kind: zkVMKind) -> Elf {
+    assert!(matches!(
+        stateless_validator_kind,
+        StatelessValidatorKind::Ethrex | StatelessValidatorKind::Reth
+    ));
     let workspace = workspace();
     let compiler =
         DockerizedCompiler::new(zkvm_kind, CompilerKind::RustCustomized, &workspace).unwrap();
     let dir = workspace
         .join("bin")
-        .join(format!("stateless-validator-{}", guest_kind.as_str()))
+        .join(format!(
+            "stateless-validator-{}",
+            stateless_validator_kind.as_str()
+        ))
         .join(zkvm_kind.as_str());
     compiler.compile(&dir, &[]).unwrap()
 }
 
 /// Downloads the prebuilt guest ELF listed in `artifact-registry.json`.
-pub fn download_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
+pub fn download_guest(
+    stateless_validator_kind: StatelessValidatorKind,
+    zkvm_kind: zkVMKind,
+) -> Elf {
     #[derive(Deserialize)]
     struct ArtifactRegistry {
         stateless_validators: Vec<StatelessValidator>,
@@ -69,11 +82,15 @@ pub fn download_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
         let json = fs::read(workspace().join("artifact-registry.json")).unwrap();
         serde_json::from_slice::<ArtifactRegistry>(&json).unwrap()
     };
-    let guest = format!("{}-{}", guest_kind.as_str(), zkvm_kind.as_str());
+    let guest = format!(
+        "{}-{}",
+        stateless_validator_kind.as_str(),
+        zkvm_kind.as_str()
+    );
     let elf = registry
         .stateless_validators
         .iter()
-        .find(|validator| validator.name == guest_kind.as_str())
+        .find(|validator| validator.name == stateless_validator_kind.as_str())
         .and_then(|validator| {
             validator
                 .elfs
@@ -102,16 +119,16 @@ pub fn init_zkvm(zkvm_kind: zkVMKind, elf: Elf) -> DockerizedzkVM {
     .unwrap()
 }
 
-/// Builds the guest, then runs `preset`'s fixtures through it on `zkvm_kind`,
-/// returning the failures.
+/// Builds the guest, then runs `fixtures` through it on `zkvm_kind`, returning
+/// the failures.
 pub fn run_stateless_validator_execution(
-    guest_kind: GuestKind,
+    stateless_validator_kind: StatelessValidatorKind,
     zkvm_kind: zkVMKind,
-    preset: FixturePreset,
+    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
 ) -> Vec<ExecutionFailure> {
-    let elf = resolve_guest(guest_kind, zkvm_kind);
+    let elf = resolve_guest(stateless_validator_kind, zkvm_kind);
     let zkvm = init_zkvm(zkvm_kind, elf);
-    run_execution(preset_fixtures(preset), &|input| {
+    run_execution(fixtures, &|input| {
         Ok(zkvm.execute(&Input::new().with_stdin(input))?.0.to_vec())
     })
 }

--- a/crates/stateless-validator-test/src/execution/zkvm.rs
+++ b/crates/stateless-validator-test/src/execution/zkvm.rs
@@ -8,6 +8,7 @@ use ere_dockerized::{
     ProverResource, zkVMKind,
 };
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
 use stateless_validator_catalog::StatelessValidatorKind;
 
 use crate::{
@@ -76,6 +77,7 @@ pub fn download_guest(
     struct GuestElf {
         zkvm: String,
         url: String,
+        sha256: String,
     }
 
     let registry = {
@@ -105,6 +107,8 @@ pub fn download_guest(
         .bytes()
         .unwrap()
         .to_vec();
+    let sha256 = const_hex::encode(Sha256::digest(&bytes));
+    assert_eq!(sha256, elf.sha256, "{guest} ELF sha256 mismatch");
     Elf(bytes)
 }
 
@@ -119,8 +123,8 @@ pub fn init_zkvm(zkvm_kind: zkVMKind, elf: Elf) -> DockerizedzkVM {
     .unwrap()
 }
 
-/// Builds the guest, then runs `fixtures` through it on `zkvm_kind`, returning
-/// the failures.
+/// Resolves the guest ELF, then runs `fixtures` through it on `zkvm_kind`,
+/// returning the failures.
 pub fn run_stateless_validator_execution(
     stateless_validator_kind: StatelessValidatorKind,
     zkvm_kind: zkVMKind,

--- a/crates/stateless-validator-test/src/execution/zkvm.rs
+++ b/crates/stateless-validator-test/src/execution/zkvm.rs
@@ -1,6 +1,6 @@
 //! Helpers for compiling guest programs and asserting their zkVM execution.
 
-use std::{collections::BTreeMap, fs, path::PathBuf, sync::LazyLock};
+use std::{fs, path::PathBuf, sync::LazyLock};
 
 use dashmap::DashMap;
 use ere_dockerized::{
@@ -50,11 +50,18 @@ pub fn compile_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
 pub fn download_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
     #[derive(Deserialize)]
     struct ArtifactRegistry {
-        stateless_validator_elf: BTreeMap<String, GuestSoure>,
+        stateless_validators: Vec<StatelessValidator>,
     }
 
     #[derive(Deserialize)]
-    struct GuestSoure {
+    struct StatelessValidator {
+        name: String,
+        elfs: Vec<GuestElf>,
+    }
+
+    #[derive(Deserialize)]
+    struct GuestElf {
+        zkvm: String,
         url: String,
     }
 
@@ -63,11 +70,18 @@ pub fn download_guest(guest_kind: GuestKind, zkvm_kind: zkVMKind) -> Elf {
         serde_json::from_slice::<ArtifactRegistry>(&json).unwrap()
     };
     let guest = format!("{}-{}", guest_kind.as_str(), zkvm_kind.as_str());
-    let source = &registry
-        .stateless_validator_elf
-        .get(&guest)
+    let elf = registry
+        .stateless_validators
+        .iter()
+        .find(|validator| validator.name == guest_kind.as_str())
+        .and_then(|validator| {
+            validator
+                .elfs
+                .iter()
+                .find(|elf| elf.zkvm == zkvm_kind.as_str())
+        })
         .unwrap_or_else(|| panic!("{guest} not found in artifact-registry.json"));
-    let bytes = reqwest::blocking::get(&source.url)
+    let bytes = reqwest::blocking::get(&elf.url)
         .unwrap()
         .error_for_status()
         .unwrap()

--- a/crates/stateless-validator-test/src/fixture.rs
+++ b/crates/stateless-validator-test/src/fixture.rs
@@ -20,6 +20,9 @@ const EEST_FIXTURES_BASE_URL: &str =
 /// Release hosting the RPC-derived fixtures from `witness-generator-spec-cli`.
 const RPC_FIXTURES_BASE_URL: &str =
     "https://github.com/han0110/ere-guests/releases/download/rpc-fixtures@v0.2.0";
+/// R2 hosting the `glamsterdam-devnet-7` stateless inputs.
+pub const R2_FIXTURES_BASE_URL: &str =
+    "https://pub-df22334654034ebab51bc096137a59d8.r2.dev/devnets/glamsterdam-devnet-7";
 
 /// A preset fixture set identifying both its source archive and its format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,6 +31,8 @@ pub enum FixturePreset {
     EestGlamsterdamDevnet7,
     /// RPC-derived fixtures from the `mainnet`.
     RpcBpo2,
+    /// RPC-derived fixtures from the `glamsterdam-devnet-7`.
+    RpcGlamsterdamDevnet7,
 }
 
 /// Download and on-disk layout details for a [`FixturePreset`].
@@ -53,6 +58,11 @@ impl FixturePreset {
                 dir: "rpc-bpo2",
                 archive_dir: "rpc-bpo2",
             },
+            Self::RpcGlamsterdamDevnet7 => FixtureSource {
+                url: format!("{R2_FIXTURES_BASE_URL}/exports/batches/56040-56049.tar.zst"),
+                dir: "rpc-glamsterdam-devnet-7/56040-56049",
+                archive_dir: "blockchain_tests",
+            },
         }
     }
 }
@@ -73,15 +83,14 @@ pub struct StatelessValidatorFixture {
 /// Returns every fixture of `preset`, downloading and unpacking its archive into
 /// the local cache on first use. Fixtures are sorted by name for determinism.
 pub fn preset_fixtures(preset: FixturePreset) -> Vec<StatelessValidatorFixture> {
-    let mut fixtures = WalkDir::new(ensure_preset(preset))
-        .into_iter()
-        .par_bridge()
-        .filter_map(Result::ok)
-        .filter(is_fixture_file)
-        .flat_map(|entry| load_fixtures(entry.path()))
-        .collect::<Vec<_>>();
-    fixtures.sort_by(|a, b| a.name.cmp(&b.name));
-    fixtures
+    let source = preset.source();
+    archive_fixtures(source.dir, &source.url, source.archive_dir)
+}
+
+/// Returns every fixture of the archive at `url`, unpacking its `archive_dir`
+/// subdirectory into `<crate>/fixtures/<dir>` on first use.
+pub fn archive_fixtures(dir: &str, url: &str, archive_dir: &str) -> Vec<StatelessValidatorFixture> {
+    load_fixtures_from_dir(ensure_fixtures(dir, url, archive_dir))
 }
 
 /// Returns whether `entry` is a recognised fixture file, namely a `.json` or
@@ -95,9 +104,22 @@ fn is_fixture_file(entry: &DirEntry) -> bool {
             .is_some_and(|name| name.ends_with(".json") || name.ends_with(".json.zst"))
 }
 
+/// Returns every fixture under `dir`, sorted by name for determinism.
+fn load_fixtures_from_dir(dir: impl AsRef<Path>) -> Vec<StatelessValidatorFixture> {
+    let mut fixtures = WalkDir::new(dir)
+        .into_iter()
+        .par_bridge()
+        .filter_map(Result::ok)
+        .filter(is_fixture_file)
+        .flat_map(|entry| load_fixtures_from_file(entry.path()))
+        .collect::<Vec<_>>();
+    fixtures.sort_by(|a, b| a.name.cmp(&b.name));
+    fixtures
+}
+
 /// Loads every fixture from a single JSON file, transparently decompressing a
 /// `.zst` file and auto-detecting the EEST or RPC layout.
-pub fn load_fixtures(path: impl AsRef<Path>) -> Vec<StatelessValidatorFixture> {
+pub fn load_fixtures_from_file(path: impl AsRef<Path>) -> Vec<StatelessValidatorFixture> {
     let path = path.as_ref();
     let bytes = fs::read(path).unwrap();
     let bytes = if path.extension().is_some_and(|ext| ext == "zst") {
@@ -139,27 +161,27 @@ pub fn load_fixtures(path: impl AsRef<Path>) -> Vec<StatelessValidatorFixture> {
         .collect()
 }
 
-/// Ensures the cached fixture directory for `preset` exists, downloading and
-/// unpacking the release archive when missing. Returns the directory.
-fn ensure_preset(preset: FixturePreset) -> PathBuf {
+/// Ensures `dir` under `<crate>/fixtures/` holds the `archive_dir` subdirectory
+/// of the archive at `url`, downloading and unpacking it when missing. Returns
+/// the directory.
+fn ensure_fixtures(dir: &str, url: &str, archive_dir: &str) -> PathBuf {
     static LOCK: Mutex<()> = Mutex::new(());
     let _guard = LOCK.lock().unwrap_or_else(|err| err.into_inner());
 
-    let source = preset.source();
     let dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("fixtures")
-        .join(source.dir);
+        .join(dir);
     if !dir.exists() {
-        download_and_unpack(&source, &dir);
+        download_and_unpack(url, archive_dir, &dir);
     }
     dir
 }
 
-/// Downloads the preset's release archive and moves its `archive_dir`
-/// subdirectory to `dir`, discarding the rest of the archive.
-fn download_and_unpack(source: &FixtureSource, dir: &Path) {
-    info!("Downloading fixture archive {}", source.url);
-    let bytes = reqwest::blocking::get(&source.url)
+/// Downloads the archive at `url` and moves its `archive_dir` subdirectory to
+/// `dir`, discarding the rest of the archive.
+fn download_and_unpack(url: &str, archive_dir: &str, dir: &Path) {
+    info!("Downloading fixture archive {url}");
+    let bytes = reqwest::blocking::get(url)
         .unwrap()
         .error_for_status()
         .unwrap()
@@ -168,11 +190,11 @@ fn download_and_unpack(source: &FixtureSource, dir: &Path) {
 
     fs::create_dir_all(dir.parent().unwrap()).unwrap();
     let tempdir = tempfile::tempdir_in(dir.parent().unwrap()).unwrap();
-    if source.url.ends_with(".tar.gz") {
+    if url.ends_with(".tar.gz") {
         Archive::new(flate2::read::GzDecoder::new(&bytes[..]))
             .unpack(tempdir.path())
             .unwrap();
-    } else if source.url.ends_with(".tar.zst") {
+    } else if url.ends_with(".tar.zst") {
         Archive::new(zstd::stream::read::Decoder::new(&bytes[..]).unwrap())
             .unpack(tempdir.path())
             .unwrap();
@@ -180,7 +202,7 @@ fn download_and_unpack(source: &FixtureSource, dir: &Path) {
         unreachable!()
     }
 
-    fs::rename(tempdir.path().join(source.archive_dir), dir).unwrap();
+    fs::rename(tempdir.path().join(archive_dir), dir).unwrap();
 }
 
 /// Wire shape of an RPC artifact produced by `witness-generator-spec-cli`.

--- a/crates/stateless-validator-test/src/fixture.rs
+++ b/crates/stateless-validator-test/src/fixture.rs
@@ -20,7 +20,7 @@ const EEST_FIXTURES_BASE_URL: &str =
 /// Release hosting the RPC-derived fixtures from `witness-generator-spec-cli`.
 const RPC_FIXTURES_BASE_URL: &str =
     "https://github.com/han0110/ere-guests/releases/download/rpc-fixtures@v0.2.0";
-/// R2 hosting the `glamsterdam-devnet-7` stateless inputs.
+/// R2 bucket hosting the `glamsterdam-devnet-7` fixtures and their batch index.
 pub const R2_FIXTURES_BASE_URL: &str =
     "https://pub-df22334654034ebab51bc096137a59d8.r2.dev/devnets/glamsterdam-devnet-7";
 

--- a/crates/stateless-validator-test/tests/zkvm_execution.rs
+++ b/crates/stateless-validator-test/tests/zkvm_execution.rs
@@ -72,5 +72,5 @@ declare_test!(Reth, Zisk, EestGlamsterdamDevnet7, failures = 39);
 
 // Zesu
 
-// ZisK `zkvm-interface` impl bug + Zesu alignment issue.
-// declare_test!(Zesu, Zisk, EestGlamsterdamDevnet5, failures = 121);
+// ZisK `zkvm-interface` impl bug.
+declare_test!(Zesu, Zisk, EestGlamsterdamDevnet7, failures = 22);

--- a/crates/stateless-validator-test/tests/zkvm_execution.rs
+++ b/crates/stateless-validator-test/tests/zkvm_execution.rs
@@ -7,18 +7,20 @@
 //! compile Reth guest.
 
 use ere_dockerized::zkVMKind;
+use stateless_validator_catalog::StatelessValidatorKind;
 use stateless_validator_test::{
-    execution::{ExecutionFailures, GuestKind, zkvm::run_stateless_validator_execution},
-    fixture::FixturePreset,
+    execution::{ExecutionFailures, zkvm::run_stateless_validator_execution},
+    fixture::{FixturePreset, preset_fixtures},
 };
 
 fn test_execution(
-    guest_kind: GuestKind,
+    stateless_validator: StatelessValidatorKind,
     zkvm_kind: zkVMKind,
     preset: FixturePreset,
     expected_failures: usize,
 ) {
-    let failures = run_stateless_validator_execution(guest_kind, zkvm_kind, preset);
+    let failures =
+        run_stateless_validator_execution(stateless_validator, zkvm_kind, preset_fixtures(preset));
     assert_eq!(
         failures.len(),
         expected_failures,
@@ -29,12 +31,12 @@ fn test_execution(
 }
 
 macro_rules! declare_test {
-    ($guest_kind:ident, $zkvm_kind:ident, $preset:ident, failures = $expected_failures:expr) => {
+    ($stateless_validator:ident, $zkvm_kind:ident, $preset:ident, failures = $expected_failures:expr) => {
         paste::paste! {
             #[test]
-            fn [<test_execution_ $guest_kind:lower _ $zkvm_kind:lower _ $preset:snake>]() {
+            fn [<test_execution_ $stateless_validator:lower _ $zkvm_kind:lower _ $preset:snake>]() {
                 test_execution(
-                    GuestKind::$guest_kind,
+                    StatelessValidatorKind::$stateless_validator,
                     zkVMKind::$zkvm_kind,
                     FixturePreset::$preset,
                     $expected_failures,
@@ -42,35 +44,45 @@ macro_rules! declare_test {
             }
         }
     };
-    ($guest_kind:ident, $zkvm_kind:ident, $preset:ident) => {
-        declare_test!($guest_kind, $zkvm_kind, $preset, failures = 0);
+    ($stateless_validator:ident, $zkvm_kind:ident, $preset:ident) => {
+        declare_test!($stateless_validator, $zkvm_kind, $preset, failures = 0);
     };
 }
 
 // Ethrex
 
 declare_test!(Ethrex, OpenVM, RpcBpo2);
+declare_test!(Ethrex, OpenVM, RpcGlamsterdamDevnet7);
 // Ethrex arithmetic overflow on 32-bit targets + OOM.
 declare_test!(Ethrex, OpenVM, EestGlamsterdamDevnet7, failures = 5);
 declare_test!(Ethrex, SP1, RpcBpo2);
+declare_test!(Ethrex, SP1, RpcGlamsterdamDevnet7);
 declare_test!(Ethrex, SP1, EestGlamsterdamDevnet7);
 declare_test!(Ethrex, Zisk, RpcBpo2);
+declare_test!(Ethrex, Zisk, RpcGlamsterdamDevnet7);
 // Ethrex OOM + ZisK `zkvm-interface` impl bug.
 declare_test!(Ethrex, Zisk, EestGlamsterdamDevnet7, failures = 26);
 
 // Reth
 
 declare_test!(Reth, OpenVM, RpcBpo2);
+// Reth divergences (in-block created-code resolution from EIP-8025).
+declare_test!(Reth, OpenVM, RpcGlamsterdamDevnet7, failures = 1);
 // Reth divergences.
 declare_test!(Reth, OpenVM, EestGlamsterdamDevnet7, failures = 17);
 declare_test!(Reth, SP1, RpcBpo2);
+// Reth divergences (in-block created-code resolution from EIP-8025).
+declare_test!(Reth, SP1, RpcGlamsterdamDevnet7, failures = 1);
 // Reth divergences.
 declare_test!(Reth, SP1, EestGlamsterdamDevnet7, failures = 17);
 declare_test!(Reth, Zisk, RpcBpo2);
+// Reth divergences (in-block created-code resolution from EIP-8025).
+declare_test!(Reth, Zisk, RpcGlamsterdamDevnet7, failures = 1);
 // Reth divergences + ZisK `zkvm-interface` impl bug.
 declare_test!(Reth, Zisk, EestGlamsterdamDevnet7, failures = 39);
 
 // Zesu
 
+declare_test!(Zesu, Zisk, RpcGlamsterdamDevnet7);
 // ZisK `zkvm-interface` impl bug.
 declare_test!(Zesu, Zisk, EestGlamsterdamDevnet7, failures = 22);


### PR DESCRIPTION
- Add `zesu-zisk` back of the [`glamsterdam-devnet-7.2`](https://github.com/Consensys/zesu-zkvm/releases/tag/glamsterdam-devnet-7.2) release
- Bump `ere` so ZisK gets the rigth Rust toolchain to compile guests
- Add selected 10 blocks from [glamsterdam-devnet-7 R2 bucket](https://pub-df22334654034ebab51bc096137a59d8.r2.dev/devnets/glamsterdam-devnet-7/index.html) as preset `RpcGlamsterdamDevnet7` and test
- Add cron workflow to test latest 100 blocks from the same R2 bucket every day.