### PR TITLE
feat: do host execution in devnet fixture tests

### DIFF
--- a/.github/workflows/integration-test-devnet.yml
+++ b/.github/workflows/integration-test-devnet.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure sccache
         run: |
@@ -114,6 +116,8 @@ jobs:
 
       - name: Setup sccache
         uses: mozilla/sccache-action@v0.0.9
+        with:
+          disable_annotations: true
 
       - name: Configure sccache
         run: |

--- a/.github/workflows/integration-test-devnet.yml
+++ b/.github/workflows/integration-test-devnet.yml
@@ -95,3 +95,57 @@ jobs:
       - name: Run sccache stat for check
         shell: bash
         run: ${SCCACHE_PATH} --show-stats
+
+  test_host_execution_devnet:
+    name: ${{ matrix.stateless_validator }} on host
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        stateless_validator:
+          - ethrex
+          - reth
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup sccache
+        uses: mozilla/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Run host execution of the latest devnet blocks
+        env:
+          RUST_LOG: info
+          CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS: true
+        run: |
+          cargo run --release --package stateless-validator-test --bin zkvm_execution_devnet -- \
+            --stateless-validator ${{ matrix.stateless_validator }} \
+            --output failures.txt
+          {
+            echo "### ${{ matrix.stateless_validator }} on host"
+            echo '```'
+            cat failures.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run sccache stat for check
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5875,6 +5875,8 @@ dependencies = [
  "sha2",
  "stateless-validator-catalog",
  "stateless-validator-common",
+ "stateless-validator-ethrex",
+ "stateless-validator-reth",
  "tar",
  "tempfile",
  "tracing",

--- a/crates/stateless-validator-ethrex/tests/host_execution.rs
+++ b/crates/stateless-validator-ethrex/tests/host_execution.rs
@@ -1,8 +1,7 @@
 //! Execution tests for `stateless-validator-ethrex` guest program on host
 
-use stateless_validator_ethrex::guest::run_stateless_guest;
 use stateless_validator_test::declare_test_host_execution;
 
-declare_test_host_execution!(RpcBpo2, run_stateless_guest);
-declare_test_host_execution!(RpcGlamsterdamDevnet7, run_stateless_guest);
-declare_test_host_execution!(EestGlamsterdamDevnet7, run_stateless_guest);
+declare_test_host_execution!(Ethrex, RpcBpo2);
+declare_test_host_execution!(Ethrex, RpcGlamsterdamDevnet7);
+declare_test_host_execution!(Ethrex, EestGlamsterdamDevnet7);

--- a/crates/stateless-validator-reth/tests/host_execution.rs
+++ b/crates/stateless-validator-reth/tests/host_execution.rs
@@ -1,12 +1,11 @@
 //! Execution tests for `stateless-validator-reth` guest program on host
 
-use stateless_validator_reth::guest::run_stateless_guest;
 use stateless_validator_test::declare_test_host_execution;
 
-declare_test_host_execution!(RpcBpo2, run_stateless_guest);
+declare_test_host_execution!(Reth, RpcBpo2);
 // NOTE:
 // - 1 EIP-8025 (in-block created-code resolution)
-declare_test_host_execution!(RpcGlamsterdamDevnet7, run_stateless_guest, failures = 1);
+declare_test_host_execution!(Reth, RpcGlamsterdamDevnet7, failures = 1);
 // NOTE:
 // - 12 EIP-7610
 //    - test_init_collision_create_tx
@@ -22,4 +21,4 @@ declare_test_host_execution!(RpcGlamsterdamDevnet7, run_stateless_guest, failure
 //    - test_witness_codes_create_same_hash_then_read
 // - 1 EIP-8037 (state creation gas for set code)
 //    - test_same_tx_clear_then_reset_pre_delegated
-declare_test_host_execution!(EestGlamsterdamDevnet7, run_stateless_guest, failures = 17);
+declare_test_host_execution!(Reth, EestGlamsterdamDevnet7, failures = 17);

--- a/crates/stateless-validator-test/Cargo.toml
+++ b/crates/stateless-validator-test/Cargo.toml
@@ -36,6 +36,8 @@ ere-platform-core.workspace = true
 # local
 stateless-validator-catalog.workspace = true
 stateless-validator-common = { workspace = true, features = ["host"] }
+stateless-validator-ethrex = { workspace = true, features = ["host"] }
+stateless-validator-reth = { workspace = true, features = ["host"] }
 
 [dev-dependencies]
 paste.workspace = true

--- a/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
+++ b/crates/stateless-validator-test/src/bin/zkvm_execution_devnet.rs
@@ -1,5 +1,6 @@
 //! Runs the latest blocks published in the devnet catalog through a stateless
-//! validator guest program in a zkVM, reporting the failures.
+//! validator guest program, in a zkVM or, when no zkVM is selected, natively on
+//! the host, reporting the failures.
 //!
 //! Run with env `ERE_IMAGE_REGISTRY=ghcr.io/eth-act/ere` to use the pre-built
 //! image as the executor.
@@ -14,9 +15,12 @@ use ere_dockerized::zkVMKind;
 use serde::Deserialize;
 use stateless_validator_catalog::StatelessValidatorKind;
 use stateless_validator_test::{
-    execution::{ExecutionFailures, zkvm::run_stateless_validator_execution},
+    execution::{
+        ExecutionFailures, host::run_host_execution, init_tracing, zkvm::run_zkvm_execution,
+    },
     fixture::{R2_FIXTURES_BASE_URL, StatelessValidatorFixture, archive_fixtures},
 };
+use tracing::info;
 
 /// Subdirectory under `<crate>/fixtures/` holding the unpacked devnet batches.
 const DEVNET_FIXTURES_DIR: &str = "rpc-glamsterdam-devnet-7";
@@ -25,14 +29,14 @@ const DEVNET_FIXTURES_DIR: &str = "rpc-glamsterdam-devnet-7";
 #[derive(Debug, Clone, PartialEq, Eq, Parser)]
 #[command(
     name = "zkvm_execution_devnet",
-    about = "Run the latest devnet blocks through a stateless validator guest in a zkVM.",
+    about = "Run the latest devnet blocks through a stateless validator guest in a zkVM or on host.",
     long_about = None,
     arg_required_else_help = true
 )]
 struct Cli {
-    /// zkVM to execute the guest on.
+    /// zkVM to execute the guest on, omit to execute the guest natively on host.
     #[arg(long)]
-    zkvm: zkVMKind,
+    zkvm: Option<zkVMKind>,
     /// Stateless validator guest to execute.
     #[arg(long)]
     stateless_validator: StatelessValidatorKind,
@@ -46,8 +50,18 @@ struct Cli {
 
 fn main() {
     let cli = Cli::parse();
+    init_tracing();
     let fixtures = latest_devnet_fixtures(cli.blocks);
-    let failures = run_stateless_validator_execution(cli.stateless_validator, cli.zkvm, fixtures);
+    info!(
+        "Running {} blocks from {} to {}",
+        fixtures.len(),
+        fixtures.first().unwrap().name,
+        fixtures.last().unwrap().name,
+    );
+    let failures = match cli.zkvm {
+        Some(zkvm) => run_zkvm_execution(cli.stateless_validator, zkvm, fixtures),
+        None => run_host_execution(cli.stateless_validator, fixtures),
+    };
     if let Some(output) = cli.output {
         fs::write(output, ExecutionFailures(&failures).to_string()).unwrap();
     }

--- a/crates/stateless-validator-test/src/execution.rs
+++ b/crates/stateless-validator-test/src/execution.rs
@@ -41,17 +41,22 @@ impl Display for ExecutionFailures<'_> {
     }
 }
 
-/// Runs `execute` over every fixture in parallel, returning the failures.
-pub fn run_execution(
-    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
-    execute: &(impl Fn(Vec<u8>) -> anyhow::Result<Vec<u8>> + Sync),
-) -> Vec<ExecutionFailure> {
+/// Installs a global tracing subscriber.
+pub fn init_tracing() {
     static INIT_TRACING: Once = Once::new();
     INIT_TRACING.call_once(|| {
         let _ = tracing_subscriber::fmt()
             .with_env_filter(EnvFilter::from_default_env())
             .try_init();
     });
+}
+
+/// Runs `execute` over every fixture in parallel, returning the failures.
+pub fn run_execution(
+    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
+    execute: &(impl Fn(Vec<u8>) -> anyhow::Result<Vec<u8>> + Sync),
+) -> Vec<ExecutionFailure> {
+    init_tracing();
 
     let fixtures = fixtures.into_iter().collect::<Vec<_>>();
     let total = fixtures.len();

--- a/crates/stateless-validator-test/src/execution/host.rs
+++ b/crates/stateless-validator-test/src/execution/host.rs
@@ -3,10 +3,11 @@
 use std::io::{self, Write};
 
 use ere_platform_core::Platform;
+use stateless_validator_catalog::StatelessValidatorKind;
 
 use crate::{
-    execution::{ExecutionFailures, run_execution},
-    fixture::{FixturePreset, preset_fixtures},
+    execution::{ExecutionFailure, ExecutionFailures, run_execution},
+    fixture::{FixturePreset, StatelessValidatorFixture, preset_fixtures},
 };
 
 /// A platform for host-side guest execution.
@@ -30,13 +31,34 @@ impl Platform for HostPlatform {
     }
 }
 
-/// Test execution on host.
+/// Resolves the native guest entrypoint for `stateless_validator_kind`, then runs `fixtures`
+/// through it on the host, returning the failures.
+pub fn run_host_execution(
+    stateless_validator_kind: StatelessValidatorKind,
+    fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,
+) -> Vec<ExecutionFailure> {
+    let execute: fn(&[u8]) -> Vec<u8> = match stateless_validator_kind {
+        StatelessValidatorKind::Ethrex => {
+            stateless_validator_ethrex::guest::run_stateless_guest::<HostPlatform>
+        }
+        StatelessValidatorKind::Reth => {
+            stateless_validator_reth::guest::run_stateless_guest::<HostPlatform>
+        }
+        StatelessValidatorKind::Zesu => {
+            panic!("host execution is not supported for the zesu guest")
+        }
+    };
+    run_execution(fixtures, &|input| Ok(execute(&input)))
+}
+
+/// Runs `preset` on the host through the `stateless_validator_kind` guest, asserting the failure
+/// count matches `expected_failures`.
 pub fn test_host_execution(
+    stateless_validator_kind: StatelessValidatorKind,
     preset: FixturePreset,
-    execute: fn(&[u8]) -> Vec<u8>,
     expected_failures: usize,
 ) {
-    let failures = run_execution(preset_fixtures(preset), &|input| Ok(execute(&input)));
+    let failures = run_host_execution(stateless_validator_kind, preset_fixtures(preset));
     assert_eq!(
         failures.len(),
         expected_failures,
@@ -46,26 +68,22 @@ pub fn test_host_execution(
     );
 }
 
-/// Declares a host execution test for a fixture preset and guest entrypoint.
+/// Declares a host execution test for a guest kind and fixture preset.
 #[macro_export]
 macro_rules! declare_test_host_execution {
-    ($preset:ident, $execute:ident, failures = $expected_failures:expr) => {
+    ($kind:ident, $preset:ident, failures = $expected_failures:expr) => {
         paste::paste! {
             #[test]
             fn [<test_host_execution_ $preset:snake>]() {
-                use $crate::{
-                    execution::host::{HostPlatform, test_host_execution},
-                    fixture::FixturePreset,
-                };
-                test_host_execution(
-                    FixturePreset::$preset,
-                    $execute::<HostPlatform>,
+                $crate::execution::host::test_host_execution(
+                    $crate::StatelessValidatorKind::$kind,
+                    $crate::fixture::FixturePreset::$preset,
                     $expected_failures,
                 );
             }
         }
     };
-    ($preset:ident, $execute:ident) => {
-        $crate::declare_test_host_execution!($preset, $execute, failures = 0);
+    ($kind:ident, $preset:ident) => {
+        $crate::declare_test_host_execution!($kind, $preset, failures = 0);
     };
 }

--- a/crates/stateless-validator-test/src/execution/zkvm.rs
+++ b/crates/stateless-validator-test/src/execution/zkvm.rs
@@ -125,7 +125,7 @@ pub fn init_zkvm(zkvm_kind: zkVMKind, elf: Elf) -> DockerizedzkVM {
 
 /// Resolves the guest ELF, then runs `fixtures` through it on `zkvm_kind`,
 /// returning the failures.
-pub fn run_stateless_validator_execution(
+pub fn run_zkvm_execution(
     stateless_validator_kind: StatelessValidatorKind,
     zkvm_kind: zkVMKind,
     fixtures: impl IntoIterator<Item = StatelessValidatorFixture>,

--- a/crates/stateless-validator-test/src/lib.rs
+++ b/crates/stateless-validator-test/src/lib.rs
@@ -1,4 +1,6 @@
 //! Test helpers for the stateless validator guests.
 
+pub use stateless_validator_catalog::StatelessValidatorKind;
+
 pub mod execution;
 pub mod fixture;

--- a/crates/stateless-validator-test/tests/zkvm_execution.rs
+++ b/crates/stateless-validator-test/tests/zkvm_execution.rs
@@ -9,7 +9,7 @@
 use ere_dockerized::zkVMKind;
 use stateless_validator_catalog::StatelessValidatorKind;
 use stateless_validator_test::{
-    execution::{ExecutionFailures, zkvm::run_stateless_validator_execution},
+    execution::{ExecutionFailures, zkvm::run_zkvm_execution},
     fixture::{FixturePreset, preset_fixtures},
 };
 
@@ -19,8 +19,7 @@ fn test_execution(
     preset: FixturePreset,
     expected_failures: usize,
 ) {
-    let failures =
-        run_stateless_validator_execution(stateless_validator, zkvm_kind, preset_fixtures(preset));
+    let failures = run_zkvm_execution(stateless_validator, zkvm_kind, preset_fixtures(preset));
     assert_eq!(
         failures.len(),
         expected_failures,


### PR DESCRIPTION
- Includes host execution in CI `Integration test devnet`, [sample run](https://github.com/eth-act/ere-guests/actions/runs/30081940067#summary-89445295988) and it shows that host run of Reth is also failing, so probably not a zkVM issue (it's the EIP8025 in-block created-code resolution issue)
- Mute sccache report
