### PR TITLE
feat: remove reth patch

### DIFF
--- a/.github/workflows/compile-and-release.yml
+++ b/.github/workflows/compile-and-release.yml
@@ -36,6 +36,8 @@ jobs:
           - stateless_validator: ethrex
             zkvm: zisk
             ere_profile: ethrex
+          - stateless_validator: reth
+            compiler_args: --ignore-rust-version
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -79,7 +81,9 @@ jobs:
             --compiler-kind rust-customized \
             --guest-dir /ere-guests/bin/stateless-validator-${{ matrix.stateless_validator }}/${{ matrix.zkvm }} \
             --output-dir /output \
-            --elf-name ${{ steps.get_artifact_name.outputs.artifact_name }}.elf
+            --elf-name ${{ steps.get_artifact_name.outputs.artifact_name }}.elf \
+            -- \
+            ${{ matrix.compiler_args }}
 
       - name: Compile ZisK guest with feature cycle-scope enabled
         if: ${{ matrix.zkvm == 'zisk' }}
@@ -96,7 +100,8 @@ jobs:
             --output-dir /output \
             --elf-name ${{ steps.get_artifact_name.outputs.artifact_name }}-profiling.elf \
             -- \
-            --features cycle-scope
+            --features cycle-scope \
+            ${{ matrix.compiler_args }}
 
       - name: Generate program VK
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -168,13 +168,14 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -190,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -217,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -230,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -247,7 +248,6 @@ dependencies = [
  "paste",
  "rand 0.9.4",
  "ruint",
- "rustc-hash",
  "serde",
  "sha3 0.11.0",
 ]
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1f682c4881aa7000ac7cc86d7aeeb3b09836a77a90b329820140233651aeea"
+checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -488,14 +488,14 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -504,9 +504,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -516,14 +527,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint 0.4.6",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -536,10 +568,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "educe",
@@ -551,10 +583,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint 0.4.6",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -574,18 +633,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint 0.4.6",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -594,9 +681,21 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
  "arrayvec",
+ "digest 0.10.7",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint 0.4.6",
 ]
@@ -613,10 +712,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -1613,7 +1733,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-catalog"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-util-build",
  "serde",
@@ -1623,12 +1743,12 @@ dependencies = [
 [[package]]
 name = "ere-codec"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-compiler-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "serde",
 ]
@@ -1636,7 +1756,7 @@ dependencies = [
 [[package]]
 name = "ere-dockerized"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "anyhow",
  "ere-catalog",
@@ -1653,12 +1773,12 @@ dependencies = [
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-prover-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "anyhow",
  "auto_impl",
@@ -1675,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "ere-server-api"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "prost",
  "serde",
@@ -1685,7 +1805,7 @@ dependencies = [
 [[package]]
 name = "ere-server-client"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "bincode 2.0.1",
  "ere-prover-core",
@@ -1697,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "ere-util-build"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "cargo_metadata",
 ]
@@ -1705,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "ere-util-tokio"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "tokio",
 ]
@@ -1713,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "ere-verifier-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "auto_impl",
  "ere-codec",
@@ -1784,7 +1904,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "tracing",
 ]
@@ -1794,9 +1914,9 @@ name = "ethrex-crypto"
 version = "23.0.0"
 source = "git+https://github.com/lambdaclass/ethrex.git?tag=v23.0.0#d906f10655f0ae746af46abef38fb212b48acaca"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
  "blst",
  "ethereum-types",
  "hex-literal 0.4.1",
@@ -1805,9 +1925,9 @@ dependencies = [
  "malachite",
  "num-bigint 0.4.6",
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ripemd",
+ "ripemd 0.1.3",
  "secp256k1",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "tiny-keccak",
 ]
@@ -1966,6 +2086,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -2255,7 +2384,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_arrays 0.1.0",
- "sha2",
+ "sha2 0.10.9",
  "static_assertions",
  "subtle",
  "unroll",
@@ -2301,6 +2430,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -2770,7 +2900,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -2835,7 +2965,7 @@ dependencies = [
  "ff",
  "hex",
  "serde_arrays 0.2.0",
- "sha2",
+ "sha2 0.10.9",
  "sp1_bls12_381",
  "spin 0.9.8",
 ]
@@ -2850,7 +2980,7 @@ dependencies = [
  "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "sha3 0.10.9",
 ]
 
@@ -2926,7 +3056,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3773,7 +3903,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org/openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "openvm-sha2-guest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3799,7 +3929,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4042,9 +4172,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -4053,9 +4183,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -4063,9 +4193,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -4076,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -4501,8 +4631,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -4521,8 +4651,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4538,8 +4669,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4548,8 +4680,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4562,8 +4694,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4575,8 +4707,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4585,8 +4717,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4601,8 +4733,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -4613,8 +4745,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4627,8 +4759,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4637,6 +4769,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more 2.1.1",
+ "fixed-cache",
  "futures-util",
  "reth-execution-errors",
  "reth-execution-types",
@@ -4649,8 +4782,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4669,8 +4802,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -4682,8 +4815,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4698,8 +4831,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4710,8 +4843,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -4720,8 +4853,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4745,8 +4879,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -4757,8 +4891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -4766,8 +4900,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more 2.1.1",
@@ -4779,8 +4913,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -4802,8 +4936,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -4819,8 +4953,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -4835,16 +4969,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -4861,8 +4997,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
  "phf",
@@ -4872,8 +5009,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -4887,8 +5025,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -4901,8 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "derive_more 2.1.1",
  "either",
@@ -4914,8 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -4926,8 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -4943,8 +5085,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -4958,8 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -4969,14 +5113,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
  "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
  "cfg-if",
@@ -4984,14 +5129,15 @@ dependencies = [
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "revm-context-interface",
  "revm-primitives",
- "ripemd",
- "sha2",
+ "ripemd 0.2.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -5000,8 +5146,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -5042,6 +5189,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5458,6 +5614,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5667,7 +5834,7 @@ dependencies = [
  "lazy_static",
  "num-bigint 0.4.6",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "slop-algebra",
  "slop-bn254",
  "slop-challenger",
@@ -5723,7 +5890,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -5768,7 +5935,7 @@ dependencies = [
  "libssz-merkle",
  "libssz-types",
  "paste",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -5874,7 +6041,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "stateless-validator-catalog",
  "stateless-validator-common",
  "stateless-validator-ethrex",
@@ -6368,7 +6535,7 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -6961,7 +7128,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,24 +63,24 @@ walkdir = "2.5.0"
 zstd = "0.13.3"
 
 # alloy
-alloy-consensus = { version = "2.1.1", default-features = false }
-alloy-eips = { version = "2.1.1", default-features = false }
-alloy-genesis = { version = "2.1.1", default-features = false }
-alloy-primitives = { version = "1.6.0", default-features = false }
-alloy-rpc-types-engine = { version = "2.1.1", default-features = false }
+alloy-consensus = { version = "2.2.0", default-features = false }
+alloy-eips = { version = "2.2.0", default-features = false }
+alloy-genesis = { version = "2.2.0", default-features = false }
+alloy-primitives = { version = "1.6.1", default-features = false }
+alloy-rpc-types-engine = { version = "2.2.0", default-features = false }
 
 # revm
-revm = { version = "41.0.0", default-features = false }
+revm = { version = "42.0.1", default-features = false }
 
 # reth
-# FIXME: Switch back to a released tag once glamsterdam-devnet-7 lands upstream and zkVM compiler verison is bumped to 1.95.
-reth-chainspec = { git = "https://github.com/han0110/reth", rev = "c5dff62a8804b207659f5d1f30f13e66c3a66d4b", default-features = false }
-reth-ethereum-primitives = { git = "https://github.com/han0110/reth", rev = "c5dff62a8804b207659f5d1f30f13e66c3a66d4b", default-features = false }
-reth-evm-ethereum = { git = "https://github.com/han0110/reth", rev = "c5dff62a8804b207659f5d1f30f13e66c3a66d4b", default-features = false }
-reth-payload-validator = { git = "https://github.com/han0110/reth", rev = "c5dff62a8804b207659f5d1f30f13e66c3a66d4b", default-features = false }
-reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-stateless = { git = "https://github.com/han0110/stateless", rev = "711c3f91a41e656c1f0aaecd70b62c1bc8df2d06", default-features = false, package = "stateless" }
-reth-tries = { git = "https://github.com/han0110/stateless", rev = "711c3f91a41e656c1f0aaecd70b62c1bc8df2d06", default-features = false, package = "tries" }
+# FIXME: Switch back to a released tag once glamsterdam-devnet-7 is released.
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f804dc1eaa06927b1bdf17f2b67572f6f6b2deee", default-features = false }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f804dc1eaa06927b1bdf17f2b67572f6f6b2deee", default-features = false }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f804dc1eaa06927b1bdf17f2b67572f6f6b2deee", default-features = false }
+reth-payload-validator = { git = "https://github.com/paradigmxyz/reth", rev = "f804dc1eaa06927b1bdf17f2b67572f6f6b2deee", default-features = false }
+reth-primitives-traits = { version = "0.6.0", default-features = false }
+reth-stateless = { git = "https://github.com/han0110/stateless", rev = "b2520535b14ab8fec4ee3b14f28c4136f1e25400", default-features = false, package = "stateless" }
+reth-tries = { git = "https://github.com/han0110/stateless", rev = "b2520535b14ab8fec4ee3b14f28c4136f1e25400", default-features = false, package = "tries" }
 
 # ethrex
 ethrex-common = { git = "https://github.com/lambdaclass/ethrex.git", tag = "v23.0.0", default-features = false }
@@ -108,10 +108,10 @@ bls12_381 = { git = "https://github.com/zkcrypto/bls12_381", rev = "6bb96951d5c2
 zkvm-interface = { git = "https://github.com/eth-act/zkvm-standards", rev = "282cd356c3a0498416bb0619f9c8a347ce9933fb" }
 
 # ere
-ere-catalog = { git = "https://github.com/eth-act/ere", tag = "v0.14.0" }
-ere-dockerized = { git = "https://github.com/eth-act/ere", tag = "v0.14.0" }
-ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.14.0" }
-ere-util-build = { git = "https://github.com/eth-act/ere", tag = "v0.14.0" }
+ere-catalog = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2" }
+ere-dockerized = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2" }
+ere-platform-core = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2" }
+ere-util-build = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2" }
 
 # local
 stateless-validator-catalog = { path = "crates/stateless-validator-catalog" }
@@ -120,24 +120,3 @@ stateless-validator-debug = { path = "crates/stateless-validator-debug", default
 stateless-validator-ethrex = { path = "crates/stateless-validator-ethrex", default-features = false }
 stateless-validator-reth = { path = "crates/stateless-validator-reth", default-features = false }
 stateless-validator-test = { path = "crates/stateless-validator-test", default-features = false }
-
-# FIXME: Remove the patch once glamsterdam-devnet-7 lands upstream.
-# Taken from https://github.com/paradigmxyz/reth/blob/9acd64229e4667d94690c2976e6f8f547ba49d7c/Cargo.toml
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }

--- a/bin/stateless-validator-ethrex/openvm/Cargo.lock
+++ b/bin/stateless-validator-ethrex/openvm/Cargo.lock
@@ -686,12 +686,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-platform-openvm"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-platform-core",
  "openvm",

--- a/bin/stateless-validator-ethrex/openvm/Cargo.toml
+++ b/bin/stateless-validator-ethrex/openvm/Cargo.toml
@@ -14,7 +14,7 @@ openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", tag =
 openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", tag = "v2.0.0" }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.14.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2", features = [
     "std",
 ] }
 

--- a/bin/stateless-validator-ethrex/sp1/Cargo.lock
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.lock
@@ -821,12 +821,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-platform-sp1"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-platform-core",
  "libzkevm",

--- a/bin/stateless-validator-ethrex/sp1/Cargo.toml
+++ b/bin/stateless-validator-ethrex/sp1/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.14.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2" }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-ethrex/zisk/Cargo.lock
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.lock
@@ -774,12 +774,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-platform-zisk"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-platform-core",
  "ziskos",

--- a/bin/stateless-validator-ethrex/zisk/Cargo.toml
+++ b/bin/stateless-validator-ethrex/zisk/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.0"
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.14.0", default-features = false, features = ["inputcpy"] }
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2", default-features = false, features = ["inputcpy"] }
 
 # local
 stateless-validator-ethrex = { path = "../../../crates/stateless-validator-ethrex", features = [

--- a/bin/stateless-validator-reth/openvm/Cargo.lock
+++ b/bin/stateless-validator-reth/openvm/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -125,9 +125,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -142,13 +142,14 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -164,9 +165,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -191,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -204,9 +205,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -221,7 +222,6 @@ dependencies = [
  "paste",
  "rand 0.9.4",
  "ruint",
- "rustc-hash",
  "serde",
  "sha3",
 ]
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1f682c4881aa7000ac7cc86d7aeeb3b09836a77a90b329820140233651aeea"
+checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -292,7 +292,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools",
  "serde",
  "serde_json",
  "thiserror",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -385,9 +385,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -420,9 +420,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -431,8 +431,8 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -441,29 +441,26 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "educe",
- "itertools 0.13.0",
  "num-bigint",
  "num-traits",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -471,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -484,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -494,27 +491,26 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "num-bigint",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -523,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -1110,12 +1106,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-platform-openvm"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-platform-core",
  "openvm",
@@ -1143,6 +1139,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+]
 
 [[package]]
 name = "fixed-map"
@@ -1292,7 +1297,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_arrays",
- "sha2",
+ "sha2 0.10.9",
  "static_assertions",
  "subtle",
  "unroll",
@@ -1321,6 +1326,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -1503,15 +1509,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1545,7 +1542,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1624,7 +1621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2023,7 +2020,7 @@ source = "git+https://github.com/openvm-org//openvm.git?tag=v2.0.0#15a7ab6baed03
 dependencies = [
  "group",
  "hex-literal",
- "itertools 0.14.0",
+ "itertools",
  "num-bigint",
  "num-traits",
  "openvm",
@@ -2045,7 +2042,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org//openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "hex-literal",
- "itertools 0.14.0",
+ "itertools",
  "lazy_static",
  "num-bigint",
  "num-traits",
@@ -2083,7 +2080,7 @@ version = "2.0.0"
 source = "git+https://github.com/openvm-org//openvm.git?tag=v2.0.0#15a7ab6baed03d75050dbef2bbad4b4e98fb8dba"
 dependencies = [
  "openvm-sha2-guest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2103,7 +2100,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2175,9 +2172,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2186,9 +2183,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -2196,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2209,9 +2206,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -2444,8 +2441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2464,8 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2481,8 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2491,8 +2490,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2505,8 +2504,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2518,8 +2517,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2528,8 +2527,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2544,8 +2543,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2556,8 +2555,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2570,8 +2569,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2580,6 +2579,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
+ "fixed-cache",
  "futures-util",
  "reth-execution-errors",
  "reth-execution-types",
@@ -2592,8 +2592,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2612,8 +2612,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2625,8 +2625,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2641,8 +2641,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2653,8 +2653,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -2663,8 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2688,8 +2689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2700,8 +2701,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2709,8 +2710,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2722,8 +2723,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2745,8 +2746,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2762,15 +2763,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-trie",
  "derive_more",
- "itertools 0.14.0",
+ "itertools",
  "nybbles",
  "reth-primitives-traits",
  "revm",
@@ -2778,16 +2779,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2804,8 +2807,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
  "phf",
@@ -2815,8 +2819,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2830,8 +2835,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -2844,8 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "derive_more",
  "either",
@@ -2857,8 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -2869,8 +2877,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -2886,8 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -2901,8 +2911,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2912,8 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -2928,13 +2940,14 @@ dependencies = [
  "revm-context-interface",
  "revm-primitives",
  "ripemd",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -2943,8 +2956,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -2966,11 +2980,11 @@ dependencies = [
 
 [[package]]
 name = "ripemd"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2994,12 +3008,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3175,6 +3183,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3246,7 +3265,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3280,7 +3299,7 @@ dependencies = [
  "libssz-merkle",
  "libssz-types",
  "paste",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -3546,7 +3565,7 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3789,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/stateless-validator-reth/openvm/Cargo.toml
+++ b/bin/stateless-validator-reth/openvm/Cargo.toml
@@ -7,16 +7,16 @@ edition = "2024"
 
 [dependencies]
 # enable features
-alloy-consensus = { version = "2.1.1", default-features = false, features = [
+alloy-consensus = { version = "2.2.0", default-features = false, features = [
     "crypto-backend",
 ] }
-alloy-primitives = { version = "1.6.0", default-features = false, features = [
+alloy-primitives = { version = "1.6.1", default-features = false, features = [
     "map-hashbrown",
     "native-keccak",
 ] }
 
 # revm
-revm = { version = "41.0.0", default-features = false }
+revm = { version = "42.0.1", default-features = false }
 
 # openvm
 openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v2.0.0", features = [
@@ -37,7 +37,7 @@ openvm-kzg = { git = "https://github.com/axiom-crypto/openvm-eth", rev = "aa8bbe
 aurora-engine-modexp = { version = "1.2.0", default-features = false }
 
 # ere
-ere-platform-openvm = { git = "https://github.com/eth-act/ere", tag = "v0.14.0", features = [
+ere-platform-openvm = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2", features = [
     "std",
 ] }
 
@@ -68,23 +68,3 @@ openvm-sha2-guest = { git = "https://github.com/openvm-org//openvm.git", tag = "
 codegen-units = 1
 lto = "fat"
 
-# FIXME: Remove the patch once glamsterdam-devnet-7 lands upstream.
-# Taken from https://github.com/paradigmxyz/reth/blob/9acd64229e4667d94690c2976e6f8f547ba49d7c/Cargo.toml
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }

--- a/bin/stateless-validator-reth/sp1/Cargo.lock
+++ b/bin/stateless-validator-reth/sp1/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -145,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -167,8 +167,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -184,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -211,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -224,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -241,7 +242,6 @@ dependencies = [
  "paste",
  "rand 0.9.4",
  "ruint",
- "rustc-hash",
  "serde",
  "sha3",
 ]
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1f682c4881aa7000ac7cc86d7aeeb3b09836a77a90b329820140233651aeea"
+checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -300,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -417,9 +417,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "ark-bn254"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -451,8 +451,8 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-integer",
  "num-traits",
@@ -461,29 +461,26 @@ dependencies = [
 
 [[package]]
 name = "ark-ff"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "educe",
- "itertools 0.13.0",
  "num-bigint 0.4.6",
  "num-traits",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.118",
@@ -491,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "ark-ff-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -504,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
  "ark-ff",
@@ -514,27 +511,26 @@ dependencies = [
  "ark-std",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "ark-serialize"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "arrayvec",
  "digest 0.10.7",
  "num-bigint 0.4.6",
 ]
 
 [[package]]
 name = "ark-serialize-derive"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -543,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "ark-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -1229,12 +1225,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-platform-sp1"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-platform-core",
  "libzkevm",
@@ -1280,6 +1276,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+]
 
 [[package]]
 name = "fixed-map"
@@ -1481,19 +1486,11 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash",
  "serde",
  "serde_core",
@@ -1848,7 +1845,7 @@ dependencies = [
  "kzg-rs",
  "num-bigint-dig",
  "p256 0.13.2 (git+https://github.com/sp1-patches/elliptic-curves?tag=patch-p256-13.2-sp1-6.2.0)",
- "ripemd",
+ "ripemd 0.1.3",
  "sha2 0.10.9 (git+https://github.com/sp1-patches/RustCrypto-hashes?tag=patch-sha2-0.10.9-sp1-6.2.0)",
  "sp1-zkvm",
  "substrate-bn",
@@ -2308,9 +2305,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2319,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -2329,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2342,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -2604,8 +2601,8 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2624,8 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2641,8 +2639,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2651,8 +2650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2665,8 +2664,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2678,8 +2677,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2688,8 +2687,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2704,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2716,8 +2715,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2730,8 +2729,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2740,6 +2739,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
+ "fixed-cache",
  "futures-util",
  "reth-execution-errors",
  "reth-execution-types",
@@ -2752,8 +2752,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2772,8 +2772,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2785,8 +2785,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2801,8 +2801,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2813,8 +2813,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -2823,8 +2823,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2848,8 +2849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2860,8 +2861,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2869,8 +2870,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2882,8 +2883,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2905,8 +2906,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2922,8 +2923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2938,16 +2939,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2964,8 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
  "phf",
@@ -2975,8 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2990,8 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3004,8 +3010,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "derive_more",
  "either",
@@ -3017,8 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -3029,8 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -3046,8 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -3061,8 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3072,8 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3087,14 +3099,15 @@ dependencies = [
  "p256 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "revm-context-interface",
  "revm-primitives",
- "ripemd",
- "sha2 0.10.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ripemd 0.2.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -3103,8 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -3140,6 +3154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3364,6 +3387,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3567,7 +3601,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3874,7 +3908,7 @@ dependencies = [
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -4113,7 +4147,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",

--- a/bin/stateless-validator-reth/sp1/Cargo.toml
+++ b/bin/stateless-validator-reth/sp1/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2024"
 
 [dependencies]
 # enable features
-alloy-primitives = { version = "1.6.0", default-features = false, features = [
+alloy-primitives = { version = "1.6.1", default-features = false, features = [
     "map-foldhash",
     "native-keccak",
 ] }
 
 # ere
-ere-platform-sp1 = { git = "https://github.com/eth-act/ere", tag = "v0.14.0" }
+ere-platform-sp1 = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2" }
 
 # local
 stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", features = [
@@ -23,26 +23,6 @@ stateless-validator-reth = { path = "../../../crates/stateless-validator-reth", 
 [patch.crates-io]
 # FIXME: Remove the patch once https://github.com/succinctlabs/sp1/pull/2865 is merged and released.
 sp1-lib = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac" }
-
-# FIXME: Remove the patch once glamsterdam-devnet-7 lands upstream.
-# Taken from https://github.com/paradigmxyz/reth/blob/9acd64229e4667d94690c2976e6f8f547ba49d7c/Cargo.toml
-revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
 
 [patch."https://github.com/succinctlabs/sp1.git"]
 sp1-lib = { git = "https://github.com/han0110/sp1", rev = "8564a70ea1952826fc0926eba5a3ce62af53ffac" }

--- a/bin/stateless-validator-reth/zisk/Cargo.lock
+++ b/bin/stateless-validator-reth/zisk/Cargo.lock
@@ -44,9 +44,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -151,13 +151,14 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
-source = "git+https://github.com/alloy-rs/evm?rev=721c59b9e4f640c9e646c0516e5be7142c956a26#721c59b9e4f640c9e646c0516e5be7142c956a26"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -173,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -200,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -213,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -230,7 +231,6 @@ dependencies = [
  "paste",
  "rand 0.9.4",
  "ruint",
- "rustc-hash",
  "serde",
  "sha3",
 ]
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1f682c4881aa7000ac7cc86d7aeeb3b09836a77a90b329820140233651aeea"
+checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -410,10 +410,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -422,9 +434,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -434,14 +457,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff",
- "ark-poly",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -454,10 +498,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
 dependencies = [
- "ark-ff-asm",
- "ark-ff-macros",
- "ark-serialize",
- "ark-std",
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "educe",
@@ -469,10 +513,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn",
@@ -492,18 +563,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ark-poly"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff",
- "ark-serialize",
- "ark-std",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -512,9 +611,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bd211c48debd3037b48873a7aa22c3aba034e83388aa4124795c9f220b88c7"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -523,9 +622,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf8be5820de567729bfa73a410ddd07cec8ad102d9a4bf61fd6b2e60db264e8"
 dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -534,9 +633,21 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
- "ark-std",
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
  "arrayvec",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -553,10 +664,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -1141,12 +1273,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "ere-platform-core"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 
 [[package]]
 name = "ere-platform-zisk"
 version = "0.14.0"
-source = "git+https://github.com/eth-act/ere?tag=v0.14.0#2ef473c4a6ba5aefb29dc6718b9deeef5119b8bb"
+source = "git+https://github.com/eth-act/ere?rev=7e8e2ba1001f7776547f0576e4eb49bd0155e0d2#7e8e2ba1001f7776547f0576e4eb49bd0155e0d2"
 dependencies = [
  "ere-platform-core",
  "ziskos",
@@ -1184,6 +1316,15 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+]
 
 [[package]]
 name = "fixed-map"
@@ -1327,6 +1468,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash",
  "serde",
  "serde_core",
@@ -1542,7 +1684,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1615,7 +1757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63c6d6d5ce5d79bba66bc98c99869eedffedf7f14f0aa0915f1a62802650bdf6"
 dependencies = [
  "libssz",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1856,7 +1998,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1886,9 +2028,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -1897,9 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
 dependencies = [
  "fastrand",
  "phf_shared",
@@ -1907,9 +2049,9 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -1920,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -1984,9 +2126,9 @@ name = "precompiles-helpers"
 version = "1.0.0-alpha"
 source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
 dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ff",
+ "ark-bls12-381 0.5.0",
+ "ark-bn254 0.5.0",
+ "ark-ff 0.5.0",
  "ark-secp256k1",
  "ark-secp256r1",
  "cfg-if",
@@ -2203,8 +2345,8 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -2223,8 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2240,8 +2383,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2250,8 +2394,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2264,8 +2408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2277,8 +2421,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2287,8 +2431,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2303,8 +2447,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -2315,8 +2459,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2329,8 +2473,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2339,6 +2483,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
+ "fixed-cache",
  "futures-util",
  "reth-execution-errors",
  "reth-execution-types",
@@ -2351,8 +2496,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2371,8 +2516,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -2384,8 +2529,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2400,8 +2545,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -2412,8 +2557,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -2422,8 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2447,8 +2593,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2459,8 +2605,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "reth-trie-common",
@@ -2468,8 +2614,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -2481,8 +2627,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -2504,8 +2650,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -2521,8 +2667,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.0"
-source = "git+https://github.com/han0110/reth?rev=c5dff62a8804b207659f5d1f30f13e66c3a66d4b#c5dff62a8804b207659f5d1f30f13e66c3a66d4b"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=f804dc1eaa06927b1bdf17f2b67572f6f6b2deee#f804dc1eaa06927b1bdf17f2b67572f6f6b2deee"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -2537,16 +2683,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.2"
-source = "git+https://github.com/paradigmxyz/reth-core?rev=1030ec2e47bfd01956e2239ad3399bf3b5121cbe#1030ec2e47bfd01956e2239ad3399bf3b5121cbe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -2563,8 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
  "phf",
@@ -2574,8 +2723,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -2589,8 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -2603,8 +2754,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "derive_more",
  "either",
@@ -2616,8 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -2628,8 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -2645,8 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -2660,8 +2815,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -2671,14 +2827,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
+ "ark-bls12-381 0.6.0",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
  "cfg-if",
@@ -2686,14 +2843,15 @@ dependencies = [
  "p256",
  "revm-context-interface",
  "revm-primitives",
- "ripemd",
- "sha2",
+ "ripemd 0.2.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -2702,8 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
-source = "git+https://github.com/bluealloy/revm?rev=335a35ddb370b667bff248109524a4efc589213f#335a35ddb370b667bff248109524a4efc589213f"
+version = "42.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928",
  "bitflags",
@@ -2730,6 +2889,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2936,6 +3104,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,7 +3180,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stateless"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3035,7 +3214,7 @@ dependencies = [
  "libssz-merkle",
  "libssz-types",
  "paste",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -3264,7 +3443,7 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 [[package]]
 name = "tries"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3503,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "zeth-mpt"
 version = "0.1.0"
-source = "git+https://github.com/han0110/stateless?rev=711c3f91a41e656c1f0aaecd70b62c1bc8df2d06#711c3f91a41e656c1f0aaecd70b62c1bc8df2d06"
+source = "git+https://github.com/han0110/stateless?rev=b2520535b14ab8fec4ee3b14f28c4136f1e25400#b2520535b14ab8fec4ee3b14f28c4136f1e25400"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -3529,10 +3708,10 @@ name = "ziskos"
 version = "1.0.0-alpha"
 source = "git+https://github.com/0xPolygonHermez/zisk.git?tag=v1.0.0-alpha#4b9f758fabc4955cac20af837019ccc31b803a46"
 dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff",
- "ark-serialize",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
  "aurora-engine-modexp",
  "bincode",
  "blst",
@@ -3547,10 +3726,10 @@ dependencies = [
  "num-traits",
  "precompiles-helpers",
  "rand 0.8.6",
- "ripemd",
+ "ripemd 0.1.3",
  "secp256k1 0.31.1",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tiny-keccak",
  "zisk-definitions",
  "zisk-verifier",

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 
 [dependencies]
 # enable features
-alloy-primitives = { version = "1.6.0", default-features = false, features = [
+alloy-primitives = { version = "1.6.1", default-features = false, features = [
     "map-foldhash",
     "native-keccak",
 ] }
@@ -16,7 +16,7 @@ alloy-primitives = { version = "1.6.0", default-features = false, features = [
 # NOTE: Using `default-features = false, features = ["inputcpy"]` mainly to disable the other
 #       feature enabled by default `user-hints`, which this binary doesn't use but introduces lots
 #       of dependencies.
-ere-platform-zisk = { git = "https://github.com/eth-act/ere", tag = "v0.14.0", default-features = false, features = [
+ere-platform-zisk = { git = "https://github.com/eth-act/ere", rev = "7e8e2ba1001f7776547f0576e4eb49bd0155e0d2", default-features = false, features = [
     "inputcpy",
 ] }
 
@@ -39,23 +39,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(target_vendor, values("zisk"))',
 ] }
 
-# FIXME: Remove the patch once glamsterdam-devnet-7 lands upstream.
-# Taken from https://github.com/paradigmxyz/reth/blob/9acd64229e4667d94690c2976e6f8f547ba49d7c/Cargo.toml
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
-alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "721c59b9e4f640c9e646c0516e5be7142c956a26" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }
-reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "1030ec2e47bfd01956e2239ad3399bf3b5121cbe" }

--- a/crates/stateless-validator-downloader/src/lib.rs
+++ b/crates/stateless-validator-downloader/src/lib.rs
@@ -310,7 +310,6 @@ mod tests {
     use crate::Downloader;
 
     #[tokio::test]
-    #[ignore = "no tag to download yet"]
     async fn download_from_tag() -> anyhow::Result<()> {
         let guest = Downloader::from_tag("v0.14.0")
             .await?
@@ -323,13 +322,12 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "no commit to download yet"]
     async fn download_from_commit() -> anyhow::Result<()> {
         let Ok(github_token) = std::env::var("GITHUB_TOKEN") else {
             return Ok(());
         };
 
-        let guest = Downloader::from_commit("9d3d4b9", &github_token)
+        let guest = Downloader::from_commit("229ffa8", &github_token)
             .await?
             .download(StatelessValidatorKind::Reth, zkVMKind::Zisk)
             .await?;

--- a/crates/stateless-validator-reth/tests/host_execution.rs
+++ b/crates/stateless-validator-reth/tests/host_execution.rs
@@ -12,13 +12,6 @@ declare_test_host_execution!(Reth, RpcGlamsterdamDevnet7, failures = 1);
 //    - test_init_collision_create_opcode
 //    - test_collision_with_create2_revert_in_initcode
 //    - test_create2_collision_storage
-// - 2 EIP-2780 (authorization charges)
-//    - test_auth_base_net_new_only
-//    - test_multi_authorization_intra_tx_state
-// - 1 EIP-7702 (delegation clearing)
-//    - test_delegation_clearing_and_set
 // - 1 EIP-8025 (in-block created-code resolution)
 //    - test_witness_codes_create_same_hash_then_read
-// - 1 EIP-8037 (state creation gas for set code)
-//    - test_same_tx_clear_then_reset_pre_delegated
-declare_test_host_execution!(Reth, EestGlamsterdamDevnet7, failures = 17);
+declare_test_host_execution!(Reth, EestGlamsterdamDevnet7, failures = 13);

--- a/crates/stateless-validator-test/src/execution/zkvm.rs
+++ b/crates/stateless-validator-test/src/execution/zkvm.rs
@@ -54,7 +54,12 @@ pub fn compile_guest(stateless_validator_kind: StatelessValidatorKind, zkvm_kind
             stateless_validator_kind.as_str()
         ))
         .join(zkvm_kind.as_str());
-    compiler.compile(&dir, &[]).unwrap()
+    let options = match stateless_validator_kind {
+        StatelessValidatorKind::Ethrex => vec![],
+        StatelessValidatorKind::Reth => vec!["--ignore-rust-version".to_string()],
+        _ => unreachable!(),
+    };
+    compiler.compile(&dir, &options).unwrap()
 }
 
 /// Wire shape of `artifact-registry.json`.

--- a/crates/stateless-validator-test/tests/zkvm_execution.rs
+++ b/crates/stateless-validator-test/tests/zkvm_execution.rs
@@ -68,17 +68,17 @@ declare_test!(Reth, OpenVM, RpcBpo2);
 // Reth divergences (in-block created-code resolution from EIP-8025).
 declare_test!(Reth, OpenVM, RpcGlamsterdamDevnet7, failures = 1);
 // Reth divergences.
-declare_test!(Reth, OpenVM, EestGlamsterdamDevnet7, failures = 17);
+declare_test!(Reth, OpenVM, EestGlamsterdamDevnet7, failures = 13);
 declare_test!(Reth, SP1, RpcBpo2);
 // Reth divergences (in-block created-code resolution from EIP-8025).
 declare_test!(Reth, SP1, RpcGlamsterdamDevnet7, failures = 1);
 // Reth divergences.
-declare_test!(Reth, SP1, EestGlamsterdamDevnet7, failures = 17);
+declare_test!(Reth, SP1, EestGlamsterdamDevnet7, failures = 13);
 declare_test!(Reth, Zisk, RpcBpo2);
 // Reth divergences (in-block created-code resolution from EIP-8025).
 declare_test!(Reth, Zisk, RpcGlamsterdamDevnet7, failures = 1);
 // Reth divergences + ZisK `zkvm-interface` impl bug.
-declare_test!(Reth, Zisk, EestGlamsterdamDevnet7, failures = 39);
+declare_test!(Reth, Zisk, EestGlamsterdamDevnet7, failures = 35);
 
 // Zesu
 


### PR DESCRIPTION
- Bump to latest reth `glamsterdam-devnet-7` revision
- Bump ere so we can compile with `--ignore-rust-version` to compile reth even the MSRV is not satisfied (required by some features not enabled in stateless-validator)
