### PR TITLE
feat: add recursive execution proof guest logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3983,6 +3983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "recursive-execution-proof"
+version = "0.15.0"
+dependencies = [
+ "hex-literal 1.1.0",
+ "libssz",
+ "libssz-derive",
+ "libssz-merkle",
+ "libssz-types",
+ "stateless-validator-common",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,6 +5380,7 @@ version = "0.15.0"
 dependencies = [
  "anyhow",
  "const-hex",
+ "hex-literal 1.1.0",
  "libssz",
  "libssz-derive",
  "libssz-merkle",
@@ -5419,6 +5432,7 @@ dependencies = [
  "ethrex-guest-program",
  "hex-literal 1.1.0",
  "paste",
+ "recursive-execution-proof",
  "stateless-validator-common",
  "stateless-validator-test",
  "thiserror",
@@ -5438,6 +5452,7 @@ dependencies = [
  "ere-platform-core",
  "once_cell",
  "paste",
+ "recursive-execution-proof",
  "reth-chainspec",
  "reth-ethereum-primitives",
  "reth-evm-ethereum",
@@ -5464,8 +5479,10 @@ dependencies = [
  "ere-dockerized",
  "ere-platform-core",
  "flate2",
+ "libssz-merkle",
  "paste",
  "rayon",
+ "recursive-execution-proof",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "crates/recursive-execution-proof",
     "crates/stateless-validator-catalog",
     "crates/stateless-validator-debug",
     "crates/stateless-validator-common",
@@ -102,6 +103,7 @@ ere-platform-core = { git = "https://github.com/eth-act/ere", tag = "v0.15.0" }
 ere-util-build = { git = "https://github.com/eth-act/ere", tag = "v0.15.0" }
 
 # local
+recursive-execution-proof = { path = "crates/recursive-execution-proof", default-features = false }
 stateless-validator-catalog = { path = "crates/stateless-validator-catalog" }
 stateless-validator-common = { path = "crates/stateless-validator-common", default-features = false }
 stateless-validator-debug = { path = "crates/stateless-validator-debug", default-features = false }

--- a/bin/stateless-validator-reth/zisk/Cargo.toml
+++ b/bin/stateless-validator-reth/zisk/Cargo.toml
@@ -38,4 +38,3 @@ unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(zisk_hints_debug)',
     'cfg(target_vendor, values("zisk"))',
 ] }
-

--- a/crates/recursive-execution-proof/Cargo.toml
+++ b/crates/recursive-execution-proof/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "recursive-execution-proof"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+libssz.workspace = true
+libssz-derive.workspace = true
+libssz-merkle.workspace = true
+libssz-types.workspace = true
+stateless-validator-common.workspace = true
+
+[dev-dependencies]
+hex-literal.workspace = true
+
+[features]
+default = ["std"]
+std = ["stateless-validator-common/std"]

--- a/crates/recursive-execution-proof/src/lib.rs
+++ b/crates/recursive-execution-proof/src/lib.rs
@@ -1,0 +1,508 @@
+//! Shared EIP-8025 recursive execution-proof guest state machine.
+//!
+//! The consensus types implemented here follow Lighthouse's `unstable` branch at
+//! commit `e6a90c168436d8b8d6b5c779c9b0550bd56fb8c7`. Proof-system verification and
+//! client-specific stateless execution enter through narrow traits so both guest
+//! implementations use the same authenticated beacon-lineage logic.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
+use libssz_merkle::{HashTreeRoot, Sha256Hasher, hash_nodes, mix_in_active_fields};
+use libssz_types::SszList;
+use stateless_validator_common::guest::input::{
+    ChainConfig, ExecutionWitness, MAX_PUBLIC_KEYS, PUBLIC_KEY_BYTES,
+    new_payload_request::{
+        ExecutionPayloadV4, ExecutionRequestsGloas, NewPayloadRequest, NewPayloadRequestGloas,
+        VersionedHashes,
+    },
+};
+use stateless_validator_common::guest::{StatelessInput, StatelessValidationResult};
+use stateless_validator_common::{ProgressiveList, merkleize_progressive};
+
+/// A 32-byte SSZ Merkle node or consensus root.
+pub type Root = [u8; 32];
+/// A KZG commitment carried by an execution payload bid.
+pub type KzgCommitment = [u8; 48];
+/// An unbounded progressive list of KZG commitments carried by one Gloas block.
+pub type BlobKzgCommitments = ProgressiveList<KzgCommitment>;
+
+/// Maximum opaque execution-proof size from EIP-8025 (4 MiB).
+pub const MAX_PROOF_SIZE: usize = 4 * 1024 * 1024;
+/// Generalized index of `BeaconBlockBody.signed_execution_payload_bid`.
+pub const SIGNED_EXECUTION_PAYLOAD_BID_GINDEX: usize = 357;
+/// Merkle-branch depth implied by [`SIGNED_EXECUTION_PAYLOAD_BID_GINDEX`].
+pub const SIGNED_EXECUTION_PAYLOAD_BID_DEPTH: usize = 8;
+/// Subtree index implied by [`SIGNED_EXECUTION_PAYLOAD_BID_GINDEX`].
+pub const SIGNED_EXECUTION_PAYLOAD_BID_INDEX: usize = 101;
+
+/// Trusted or proven point in the execution-proof beacon lineage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+pub struct ExecutionCheckpoint {
+    /// Beacon slot of the checkpoint.
+    pub slot: u64,
+    /// Hash-tree root of the checkpoint beacon block header.
+    pub beacon_block_root: Root,
+}
+
+/// Public commitment made by a recursive execution proof.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+pub struct PublicInput {
+    /// Immutable trusted checkpoint from which recursion began.
+    pub origin: ExecutionCheckpoint,
+    /// Latest full beacon block proven by this recursive step.
+    pub head: ExecutionCheckpoint,
+}
+
+/// Opaque prior execution proof and the public input it commits to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionProof {
+    /// Proof-system-specific proof bytes.
+    pub proof_data: Vec<u8>,
+    /// Proof-system-specific identifier which the verifier binds to this guest.
+    pub proof_type: u8,
+    /// Public input committed by the proof.
+    pub public_input: PublicInput,
+}
+
+/// Minimal consensus beacon block header used by the guest.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+pub struct BeaconBlockHeader {
+    /// Beacon slot.
+    pub slot: u64,
+    /// Proposer validator index.
+    pub proposer_index: u64,
+    /// Parent beacon block root.
+    pub parent_root: Root,
+    /// Post-state root.
+    pub state_root: Root,
+    /// Beacon block body root.
+    pub body_root: Root,
+}
+
+/// Gloas execution payload bid committed by a beacon block.
+#[derive(Debug, Clone, Default, PartialEq, Eq, SszEncode, SszDecode)]
+pub struct ExecutionPayloadBid {
+    /// Parent execution block hash.
+    pub parent_block_hash: Root,
+    /// Parent beacon block root.
+    pub parent_block_root: Root,
+    /// Proposed execution block hash.
+    pub block_hash: Root,
+    /// Payload randomness value.
+    pub prev_randao: Root,
+    /// Fee recipient.
+    pub fee_recipient: [u8; 20],
+    /// Payload gas limit.
+    pub gas_limit: u64,
+    /// Builder validator index.
+    pub builder_index: u64,
+    /// Beacon slot of the bid.
+    pub slot: u64,
+    /// Bid value.
+    pub value: u64,
+    /// Execution payment.
+    pub execution_payment: u64,
+    /// Blob commitments included by the payload.
+    pub blob_kzg_commitments: BlobKzgCommitments,
+    /// Progressive-container root of execution requests.
+    pub execution_requests_root: Root,
+}
+
+impl HashTreeRoot for ExecutionPayloadBid {
+    fn hash_tree_root(&self, hasher: &impl Sha256Hasher) -> Root {
+        progressive_container_root(
+            hasher,
+            &[
+                self.parent_block_hash.hash_tree_root(hasher),
+                self.parent_block_root.hash_tree_root(hasher),
+                self.block_hash.hash_tree_root(hasher),
+                self.prev_randao.hash_tree_root(hasher),
+                self.fee_recipient.hash_tree_root(hasher),
+                self.gas_limit.hash_tree_root(hasher),
+                self.builder_index.hash_tree_root(hasher),
+                self.slot.hash_tree_root(hasher),
+                self.value.hash_tree_root(hasher),
+                self.execution_payment.hash_tree_root(hasher),
+                self.blob_kzg_commitments.hash_tree_root(hasher),
+                self.execution_requests_root.hash_tree_root(hasher),
+            ],
+        )
+    }
+}
+
+/// Signed Gloas execution payload bid.
+#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+pub struct SignedExecutionPayloadBid {
+    /// Bid message authenticated through the beacon block body root.
+    pub message: ExecutionPayloadBid,
+    /// BLS signature. See the crate-level signature-boundary documentation.
+    pub signature: [u8; 96],
+}
+
+/// Merkle proof that a signed bid is contained in a beacon block body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeaconBlockBidWitness {
+    /// Header whose body commits to `signed_bid`.
+    pub header: BeaconBlockHeader,
+    /// Complete signed bid leaf.
+    pub signed_bid: SignedExecutionPayloadBid,
+    /// Bottom-up branch at generalized index 357.
+    pub signed_bid_merkle_witness: [Root; SIGNED_EXECUTION_PAYLOAD_BID_DEPTH],
+}
+
+/// Gloas execution payload envelope message.
+#[derive(Debug, Clone, Default, PartialEq, Eq, SszEncode, SszDecode)]
+pub struct ExecutionPayloadEnvelope {
+    /// Execution payload to validate.
+    pub payload: ExecutionPayloadV4,
+    /// Execution-layer requests returned by the payload.
+    pub execution_requests: ExecutionRequestsGloas,
+    /// Builder that authored the payload.
+    pub builder_index: u64,
+    /// Beacon block root receiving the payload.
+    pub beacon_block_root: Root,
+    /// Parent beacon block root supplied to `newPayload`.
+    pub parent_beacon_block_root: Root,
+}
+
+impl HashTreeRoot for ExecutionPayloadEnvelope {
+    fn hash_tree_root(&self, hasher: &impl Sha256Hasher) -> Root {
+        progressive_container_root(
+            hasher,
+            &[
+                self.payload.hash_tree_root(hasher),
+                self.execution_requests.hash_tree_root(hasher),
+                self.builder_index.hash_tree_root(hasher),
+                self.beacon_block_root.hash_tree_root(hasher),
+                self.parent_beacon_block_root.hash_tree_root(hasher),
+            ],
+        )
+    }
+}
+
+/// Signed Gloas execution payload envelope.
+#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+pub struct SignedExecutionPayloadEnvelope {
+    /// Envelope message bound to the target bid.
+    pub message: ExecutionPayloadEnvelope,
+    /// BLS signature, intentionally not verified by this state machine.
+    pub signature: [u8; 96],
+}
+
+/// Consensus-side witness connecting a prior checkpoint to a target payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BeaconChainWitness {
+    /// Trusted checkpoint for a base proof; mutually exclusive with `previous_proof`.
+    pub origin: Option<ExecutionCheckpoint>,
+    /// Prior recursive proof; mutually exclusive with `origin`.
+    pub previous_proof: Option<ExecutionProof>,
+    /// Checkpoint, empty-block lineage, and target block witnesses.
+    pub beacon_lineage: Vec<BeaconBlockBidWitness>,
+    /// Payload envelope for the final target block.
+    pub signed_envelope: SignedExecutionPayloadEnvelope,
+}
+
+/// Complete implementation-level private input to one recursive guest step.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateInput {
+    /// Authenticated beacon lineage and target envelope.
+    pub beacon_chain_witness: BeaconChainWitness,
+    /// Execution witness consumed by the client stateless validator.
+    pub execution_witness: ExecutionWitness,
+    /// Execution chain configuration.
+    pub chain_config: ChainConfig,
+    /// Transaction public keys in payload order.
+    pub public_keys: SszList<[u8; PUBLIC_KEY_BYTES], MAX_PUBLIC_KEYS>,
+}
+
+/// Proof-system boundary for verifying the preceding recursive proof.
+pub trait ExecutionProofVerifier {
+    /// Verifies the proof and its committed public input.
+    ///
+    /// Implementations must return `true` only when `proof_type` is bound to
+    /// this exact recursive guest program.
+    fn verify_execution_proof(&self, proof: &ExecutionProof) -> bool;
+}
+
+/// Client boundary for executing one canonical stateless payload transition.
+pub trait StatelessNewPayloadVerifier {
+    /// Executes the supplied canonical stateless input and returns its typed result.
+    fn verify_stateless_new_payload(&self, input: StatelessInput) -> StatelessValidationResult;
+}
+
+/// Failure of an EIP-8025 recursive guest invariant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// `origin` and `previous_proof` were both present or both absent.
+    InvalidProofStart,
+    /// Opaque proof bytes exceed [`MAX_PROOF_SIZE`].
+    PreviousProofTooLarge,
+    /// The proof-system adapter rejected the prior proof.
+    InvalidPreviousProof,
+    /// The lineage does not contain both checkpoint and target witnesses.
+    LineageTooShort,
+    /// A bid slot does not equal the containing header slot.
+    BidSlotMismatch,
+    /// A bid's parent block root does not equal the header parent root.
+    BidParentRootMismatch,
+    /// A signed bid Merkle proof does not open to the header body root.
+    InvalidBidMerkleProof,
+    /// The first lineage witness does not equal the selected previous head.
+    CheckpointMismatch,
+    /// An included beacon block does not strictly advance the previous slot.
+    SlotNotIncreasing,
+    /// The beacon block ancestry is discontinuous.
+    BeaconAncestryMismatch,
+    /// A bid does not continue from the predecessor proof's execution head.
+    ExecutionParentMismatch,
+    /// An intermediate produced beacon block contained a full execution payload.
+    NonEmptyIntermediateBlock,
+    /// The envelope's target beacon block root is incorrect.
+    EnvelopeBeaconRootMismatch,
+    /// The envelope's parent beacon block root is incorrect.
+    EnvelopeParentRootMismatch,
+    /// The envelope and target bid name different builders.
+    EnvelopeBuilderMismatch,
+    /// The payload and target bid have different block hashes.
+    PayloadBlockHashMismatch,
+    /// The payload and target bid have different randomness values.
+    PayloadPrevRandaoMismatch,
+    /// The payload and target bid have different gas limits.
+    PayloadGasLimitMismatch,
+    /// The envelope execution requests do not match the target bid commitment.
+    ExecutionRequestsRootMismatch,
+    /// The payload slot does not equal the target header slot.
+    PayloadSlotMismatch,
+    /// The payload parent hash does not continue from the previous execution head.
+    PayloadParentHashMismatch,
+    /// Blob commitments could not fit the identically bounded versioned-hash list.
+    VersionedHashesOverflow,
+    /// The stateless validator returned a result for a different request.
+    StatelessRequestRootMismatch,
+    /// Stateless execution rejected the reconstructed payload transition.
+    StatelessValidationFailed,
+    /// The stateless validator did not echo the supplied chain configuration.
+    StatelessChainConfigMismatch,
+}
+
+/// Authenticates a complete signed bid against its containing beacon header.
+pub fn verify_beacon_block_bid_witness(
+    witness: &BeaconBlockBidWitness,
+    hasher: &impl Sha256Hasher,
+) -> Result<(), Error> {
+    if witness.signed_bid.message.slot != witness.header.slot {
+        return Err(Error::BidSlotMismatch);
+    }
+    if witness.signed_bid.message.parent_block_root != witness.header.parent_root {
+        return Err(Error::BidParentRootMismatch);
+    }
+
+    let mut root = witness.signed_bid.hash_tree_root(hasher);
+    for (level, sibling) in witness.signed_bid_merkle_witness.iter().enumerate() {
+        root = if ((SIGNED_EXECUTION_PAYLOAD_BID_INDEX >> level) & 1) == 0 {
+            hash_nodes(hasher, &root, sibling)
+        } else {
+            hash_nodes(hasher, sibling, &root)
+        };
+    }
+    if root != witness.header.body_root {
+        return Err(Error::InvalidBidMerkleProof);
+    }
+    Ok(())
+}
+
+/// Processes one base or recursive EIP-8025 guest step.
+pub fn process_private_input(
+    proof_verifier: &impl ExecutionProofVerifier,
+    stateless_verifier: &impl StatelessNewPayloadVerifier,
+    private_input: PrivateInput,
+    hasher: &impl Sha256Hasher,
+) -> Result<PublicInput, Error> {
+    let PrivateInput {
+        beacon_chain_witness,
+        execution_witness,
+        chain_config,
+        public_keys,
+    } = private_input;
+    let BeaconChainWitness {
+        origin,
+        previous_proof,
+        beacon_lineage,
+        signed_envelope,
+    } = beacon_chain_witness;
+
+    let (origin, previous_head) = match (origin, previous_proof) {
+        (Some(origin), None) => (origin, origin),
+        (None, Some(previous_proof)) => {
+            if previous_proof.proof_data.len() > MAX_PROOF_SIZE {
+                return Err(Error::PreviousProofTooLarge);
+            }
+            if !proof_verifier.verify_execution_proof(&previous_proof) {
+                return Err(Error::InvalidPreviousProof);
+            }
+            (
+                previous_proof.public_input.origin,
+                previous_proof.public_input.head,
+            )
+        }
+        _ => return Err(Error::InvalidProofStart),
+    };
+
+    if beacon_lineage.len() < 2 {
+        return Err(Error::LineageTooShort);
+    }
+
+    let checkpoint_witness = &beacon_lineage[0];
+    verify_beacon_block_bid_witness(checkpoint_witness, hasher)?;
+    if checkpoint_witness.header.slot != previous_head.slot
+        || checkpoint_witness.header.hash_tree_root(hasher) != previous_head.beacon_block_root
+    {
+        return Err(Error::CheckpointMismatch);
+    }
+
+    let mut parent_beacon_block_root = previous_head.beacon_block_root;
+    let mut previous_slot = previous_head.slot;
+    let parent_execution_block_hash = checkpoint_witness.signed_bid.message.block_hash;
+    let mut previous_bid: Option<&ExecutionPayloadBid> = None;
+
+    for witness in &beacon_lineage[1..] {
+        if witness.header.slot <= previous_slot {
+            return Err(Error::SlotNotIncreasing);
+        }
+        if witness.header.parent_root != parent_beacon_block_root {
+            return Err(Error::BeaconAncestryMismatch);
+        }
+        verify_beacon_block_bid_witness(witness, hasher)?;
+
+        let bid = &witness.signed_bid.message;
+        if bid.parent_block_hash != parent_execution_block_hash {
+            return Err(Error::ExecutionParentMismatch);
+        }
+        if previous_bid.is_some_and(|previous| bid.parent_block_hash == previous.block_hash) {
+            return Err(Error::NonEmptyIntermediateBlock);
+        }
+
+        parent_beacon_block_root = witness.header.hash_tree_root(hasher);
+        previous_slot = witness.header.slot;
+        previous_bid = Some(bid);
+    }
+
+    let Some(target) = beacon_lineage.last() else {
+        return Err(Error::LineageTooShort);
+    };
+    let target_header = &target.header;
+    let target_bid = &target.signed_bid.message;
+    let envelope = signed_envelope.message;
+    let payload = &envelope.payload;
+    let target_beacon_block_root = target_header.hash_tree_root(hasher);
+
+    if envelope.beacon_block_root != target_beacon_block_root {
+        return Err(Error::EnvelopeBeaconRootMismatch);
+    }
+    if envelope.parent_beacon_block_root != target_header.parent_root {
+        return Err(Error::EnvelopeParentRootMismatch);
+    }
+    if envelope.builder_index != target_bid.builder_index {
+        return Err(Error::EnvelopeBuilderMismatch);
+    }
+    if payload.block_hash != target_bid.block_hash {
+        return Err(Error::PayloadBlockHashMismatch);
+    }
+    if payload.prev_randao != target_bid.prev_randao {
+        return Err(Error::PayloadPrevRandaoMismatch);
+    }
+    if payload.gas_limit != target_bid.gas_limit {
+        return Err(Error::PayloadGasLimitMismatch);
+    }
+    if execution_requests_root(&envelope.execution_requests, hasher)
+        != target_bid.execution_requests_root
+    {
+        return Err(Error::ExecutionRequestsRootMismatch);
+    }
+    if payload.slot_number != target_header.slot {
+        return Err(Error::PayloadSlotMismatch);
+    }
+    if payload.parent_hash != parent_execution_block_hash {
+        return Err(Error::PayloadParentHashMismatch);
+    }
+
+    let versioned_hashes = VersionedHashes::try_from(
+        target_bid
+            .blob_kzg_commitments
+            .iter()
+            .map(|commitment| kzg_commitment_to_versioned_hash(commitment, hasher))
+            .collect::<Vec<_>>(),
+    )
+    .map_err(|_| Error::VersionedHashesOverflow)?;
+    let new_payload_request = NewPayloadRequest::Gloas(NewPayloadRequestGloas {
+        execution_payload: envelope.payload,
+        versioned_hashes,
+        parent_beacon_block_root: envelope.parent_beacon_block_root,
+        execution_requests: envelope.execution_requests,
+    });
+    let expected_request_root = new_payload_request.hash_tree_root(hasher);
+    let result = stateless_verifier.verify_stateless_new_payload(StatelessInput {
+        new_payload_request,
+        witness: execution_witness,
+        chain_config: chain_config.clone(),
+        public_keys,
+    });
+
+    if result.new_payload_request_root != expected_request_root {
+        return Err(Error::StatelessRequestRootMismatch);
+    }
+    if !result.successful_validation {
+        return Err(Error::StatelessValidationFailed);
+    }
+    if result.chain_config != chain_config {
+        return Err(Error::StatelessChainConfigMismatch);
+    }
+
+    Ok(PublicInput {
+        origin,
+        head: ExecutionCheckpoint {
+            slot: target_header.slot,
+            beacon_block_root: target_beacon_block_root,
+        },
+    })
+}
+
+/// Computes the Gloas progressive-container root of execution requests.
+pub fn execution_requests_root(
+    requests: &ExecutionRequestsGloas,
+    hasher: &impl Sha256Hasher,
+) -> Root {
+    progressive_container_root(
+        hasher,
+        &[
+            requests.deposits.hash_tree_root(hasher),
+            requests.withdrawals.hash_tree_root(hasher),
+            requests.consolidations.hash_tree_root(hasher),
+            requests.builder_deposits.hash_tree_root(hasher),
+            requests.builder_exits.hash_tree_root(hasher),
+        ],
+    )
+}
+
+/// Computes an EIP-4844 versioned hash from a KZG commitment.
+pub fn kzg_commitment_to_versioned_hash(
+    commitment: &KzgCommitment,
+    hasher: &impl Sha256Hasher,
+) -> Root {
+    let mut versioned_hash = hasher.hash(commitment);
+    versioned_hash[0] = 1;
+    versioned_hash
+}
+
+fn progressive_container_root(hasher: &impl Sha256Hasher, field_roots: &[Root]) -> Root {
+    let root = merkleize_progressive(hasher, field_roots);
+    mix_in_active_fields(hasher, &root, &alloc::vec![true; field_roots.len()])
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/recursive-execution-proof/src/tests.rs
+++ b/crates/recursive-execution-proof/src/tests.rs
@@ -1,0 +1,441 @@
+use core::cell::{Cell, RefCell};
+
+use hex_literal::hex;
+use stateless_validator_common::guest::input::{
+    ChainConfig, ExecutionWitness, ForkActivation, ForkConfig,
+    new_payload_request::{
+        ExecutionPayloadV4, ExecutionRequestsGloas, MAX_BLOB_COMMITMENTS_PER_BLOCK,
+        NewPayloadRequest,
+    },
+};
+use stateless_validator_common::guest::{StatelessInput, StatelessValidationResult};
+use stateless_validator_common::{HashTreeRoot, Sha2Hasher, SszDecode, SszEncode, SszList};
+
+use super::*;
+
+#[derive(Debug)]
+struct ProofVerifier {
+    accepted: bool,
+    calls: Cell<usize>,
+}
+
+impl ExecutionProofVerifier for ProofVerifier {
+    fn verify_execution_proof(&self, _proof: &ExecutionProof) -> bool {
+        self.calls.set(self.calls.get() + 1);
+        self.accepted
+    }
+}
+
+#[derive(Debug)]
+struct StatelessVerifier {
+    successful: bool,
+    wrong_root: bool,
+    input: RefCell<Option<StatelessInput>>,
+}
+
+impl StatelessNewPayloadVerifier for StatelessVerifier {
+    fn verify_stateless_new_payload(&self, input: StatelessInput) -> StatelessValidationResult {
+        let root = if self.wrong_root {
+            [0xff; 32]
+        } else {
+            input.new_payload_request.hash_tree_root(&Sha2Hasher)
+        };
+        let result =
+            StatelessValidationResult::new(root, self.successful, input.chain_config.clone());
+        *self.input.borrow_mut() = Some(input);
+        result
+    }
+}
+
+fn root(byte: u8) -> Root {
+    [byte; 32]
+}
+
+fn payload(parent_hash: Root, block_hash: Root, slot: u64) -> ExecutionPayloadV4 {
+    ExecutionPayloadV4 {
+        parent_hash,
+        fee_recipient: [0; 20],
+        state_root: root(1),
+        receipts_root: root(2),
+        logs_bloom: [0; 256],
+        prev_randao: root(3),
+        block_number: 1,
+        gas_limit: 30_000_000,
+        gas_used: 21_000,
+        timestamp: 1,
+        extra_data: SszList::default(),
+        base_fee_per_gas: root(4),
+        block_hash,
+        transactions: Default::default(),
+        withdrawals: Default::default(),
+        blob_gas_used: 0,
+        excess_blob_gas: 0,
+        block_access_list: Default::default(),
+        slot_number: slot,
+    }
+}
+
+fn bid(
+    parent_block_hash: Root,
+    parent_block_root: Root,
+    block_hash: Root,
+    slot: u64,
+    requests: &ExecutionRequestsGloas,
+) -> ExecutionPayloadBid {
+    ExecutionPayloadBid {
+        parent_block_hash,
+        parent_block_root,
+        block_hash,
+        prev_randao: root(3),
+        fee_recipient: [0; 20],
+        gas_limit: 30_000_000,
+        builder_index: 42,
+        slot,
+        value: 0,
+        execution_payment: 0,
+        blob_kzg_commitments: vec![[5; 48]].into(),
+        execution_requests_root: execution_requests_root(requests, &Sha2Hasher),
+    }
+}
+
+fn witness(
+    slot: u64,
+    parent_root: Root,
+    bid: ExecutionPayloadBid,
+    branch_byte: u8,
+) -> BeaconBlockBidWitness {
+    let signed_bid = SignedExecutionPayloadBid {
+        message: bid,
+        signature: [0; 96],
+    };
+    let branch = core::array::from_fn(|level| root(branch_byte.wrapping_add(level as u8)));
+    let mut body_root = signed_bid.hash_tree_root(&Sha2Hasher);
+    for (level, sibling) in branch.iter().enumerate() {
+        body_root = if ((SIGNED_EXECUTION_PAYLOAD_BID_INDEX >> level) & 1) == 0 {
+            hash_nodes(&Sha2Hasher, &body_root, sibling)
+        } else {
+            hash_nodes(&Sha2Hasher, sibling, &body_root)
+        };
+    }
+    BeaconBlockBidWitness {
+        header: BeaconBlockHeader {
+            slot,
+            proposer_index: 1,
+            parent_root,
+            state_root: root(8),
+            body_root,
+        },
+        signed_bid,
+        signed_bid_merkle_witness: branch,
+    }
+}
+
+fn base_input() -> (PrivateInput, ExecutionCheckpoint) {
+    let requests = ExecutionRequestsGloas::default();
+    let checkpoint_bid = bid(root(6), root(7), root(9), 10, &requests);
+    let checkpoint = witness(10, root(7), checkpoint_bid, 10);
+    let checkpoint_root = checkpoint.header.hash_tree_root(&Sha2Hasher);
+    let origin = ExecutionCheckpoint {
+        slot: 10,
+        beacon_block_root: checkpoint_root,
+    };
+
+    let target_payload = payload(root(9), root(11), 12);
+    let target_bid = bid(root(9), checkpoint_root, root(11), 12, &requests);
+    let target = witness(12, checkpoint_root, target_bid, 20);
+    let target_root = target.header.hash_tree_root(&Sha2Hasher);
+
+    let input = PrivateInput {
+        beacon_chain_witness: BeaconChainWitness {
+            origin: Some(origin),
+            previous_proof: None,
+            beacon_lineage: vec![checkpoint, target.clone()],
+            signed_envelope: SignedExecutionPayloadEnvelope {
+                message: ExecutionPayloadEnvelope {
+                    payload: target_payload,
+                    execution_requests: requests,
+                    builder_index: 42,
+                    beacon_block_root: target_root,
+                    parent_beacon_block_root: checkpoint_root,
+                },
+                signature: [0; 96],
+            },
+        },
+        execution_witness: ExecutionWitness::default(),
+        chain_config: ChainConfig {
+            chain_id: 1,
+            active_fork: ForkConfig::new(ForkActivation::new(Some(0), None)),
+        },
+        public_keys: SszList::default(),
+    };
+    (input, origin)
+}
+
+fn accepting_stateless() -> StatelessVerifier {
+    StatelessVerifier {
+        successful: true,
+        wrong_root: false,
+        input: RefCell::new(None),
+    }
+}
+
+#[test]
+fn public_input_has_consensus_ssz_round_trip() {
+    let public_input = PublicInput {
+        origin: ExecutionCheckpoint {
+            slot: 2,
+            beacon_block_root: root(3),
+        },
+        head: ExecutionCheckpoint {
+            slot: 10,
+            beacon_block_root: root(11),
+        },
+    };
+
+    assert_eq!(
+        PublicInput::from_ssz_bytes(&public_input.to_ssz()).unwrap(),
+        public_input
+    );
+}
+
+#[test]
+fn gloas_consensus_types_have_ssz_round_trips() {
+    let (input, _) = base_input();
+    let signed_bid = input.beacon_chain_witness.beacon_lineage[1]
+        .signed_bid
+        .clone();
+    let signed_envelope = input.beacon_chain_witness.signed_envelope;
+
+    assert_eq!(
+        SignedExecutionPayloadBid::from_ssz_bytes(&signed_bid.to_ssz()).unwrap(),
+        signed_bid
+    );
+    assert_eq!(
+        SignedExecutionPayloadEnvelope::from_ssz_bytes(&signed_envelope.to_ssz()).unwrap(),
+        signed_envelope
+    );
+}
+
+#[test]
+fn progressive_container_roots_match_lighthouse_unstable() {
+    // Generated with Lighthouse `unstable` at
+    // e6a90c168436d8b8d6b5c779c9b0550bd56fb8c7.
+    let bid = ExecutionPayloadBid::default();
+    assert_eq!(
+        bid.hash_tree_root(&Sha2Hasher),
+        hex!("83b932ee5875c06aa35328e3c3e3c976c703f2f4b1bc98e32991ceabbb2e4b63")
+    );
+    assert_eq!(
+        ExecutionPayloadEnvelope::default().hash_tree_root(&Sha2Hasher),
+        hex!("f4a18a53008d3c2c6a7c27a3ebf4c82c2c236e212be004f985f26907af0342ec")
+    );
+}
+
+#[test]
+fn base_proof_preserves_origin_and_advances_head() {
+    let (input, origin) = base_input();
+    let expected_head = input.beacon_chain_witness.beacon_lineage[1]
+        .header
+        .hash_tree_root(&Sha2Hasher);
+    let proof = ProofVerifier {
+        accepted: true,
+        calls: Cell::new(0),
+    };
+    let stateless = accepting_stateless();
+
+    let public_input = process_private_input(&proof, &stateless, input, &Sha2Hasher).unwrap();
+
+    assert_eq!(public_input.origin, origin);
+    assert_eq!(public_input.head.slot, 12);
+    assert_eq!(public_input.head.beacon_block_root, expected_head);
+    assert_eq!(proof.calls.get(), 0);
+
+    let stateless_input = stateless.input.borrow();
+    let NewPayloadRequest::Gloas(request) = &stateless_input.as_ref().unwrap().new_payload_request
+    else {
+        panic!("recursive processing must construct a Gloas request");
+    };
+    assert_eq!(request.execution_payload.parent_hash, root(9));
+    assert_eq!(request.parent_beacon_block_root, origin.beacon_block_root);
+    assert_eq!(request.versioned_hashes.len(), 1);
+    assert_eq!(
+        request.versioned_hashes[0],
+        kzg_commitment_to_versioned_hash(&[5; 48], &Sha2Hasher)
+    );
+}
+
+#[test]
+fn recursive_proof_verifies_prior_proof_and_keeps_original_origin() {
+    let (mut input, checkpoint) = base_input();
+    let original_origin = ExecutionCheckpoint {
+        slot: 2,
+        beacon_block_root: root(99),
+    };
+    input.beacon_chain_witness.origin = None;
+    input.beacon_chain_witness.previous_proof = Some(ExecutionProof {
+        proof_data: vec![1, 2, 3],
+        proof_type: 7,
+        public_input: PublicInput {
+            origin: original_origin,
+            head: checkpoint,
+        },
+    });
+    let proof = ProofVerifier {
+        accepted: true,
+        calls: Cell::new(0),
+    };
+
+    let output = process_private_input(&proof, &accepting_stateless(), input, &Sha2Hasher).unwrap();
+
+    assert_eq!(proof.calls.get(), 1);
+    assert_eq!(output.origin, original_origin);
+    assert_eq!(output.head.slot, 12);
+}
+
+#[test]
+fn rejects_unverified_prior_proof_before_execution() {
+    let (mut input, checkpoint) = base_input();
+    input.beacon_chain_witness.origin = None;
+    input.beacon_chain_witness.previous_proof = Some(ExecutionProof {
+        proof_data: Vec::new(),
+        proof_type: 7,
+        public_input: PublicInput {
+            origin: checkpoint,
+            head: checkpoint,
+        },
+    });
+    let proof = ProofVerifier {
+        accepted: false,
+        calls: Cell::new(0),
+    };
+    let stateless = accepting_stateless();
+
+    assert_eq!(
+        process_private_input(&proof, &stateless, input, &Sha2Hasher),
+        Err(Error::InvalidPreviousProof)
+    );
+    assert_eq!(proof.calls.get(), 1);
+    assert!(stateless.input.borrow().is_none());
+}
+
+#[test]
+fn rejects_tampered_bid_merkle_proof() {
+    let (mut input, _) = base_input();
+    input.beacon_chain_witness.beacon_lineage[1].signed_bid_merkle_witness[0] = root(200);
+
+    assert_eq!(
+        process_private_input(
+            &ProofVerifier {
+                accepted: true,
+                calls: Cell::new(0),
+            },
+            &accepting_stateless(),
+            input,
+            &Sha2Hasher,
+        ),
+        Err(Error::InvalidBidMerkleProof)
+    );
+}
+
+#[test]
+fn rejects_full_intermediate_beacon_block() {
+    let (mut input, _) = base_input();
+    let requests = ExecutionRequestsGloas::default();
+    let checkpoint_root = input.beacon_chain_witness.beacon_lineage[0]
+        .header
+        .hash_tree_root(&Sha2Hasher);
+    let full_intermediate = witness(
+        11,
+        checkpoint_root,
+        bid(root(9), checkpoint_root, root(9), 11, &requests),
+        40,
+    );
+    let intermediate_root = full_intermediate.header.hash_tree_root(&Sha2Hasher);
+    let target = witness(
+        12,
+        intermediate_root,
+        bid(root(9), intermediate_root, root(11), 12, &requests),
+        50,
+    );
+    input.beacon_chain_witness.beacon_lineage = vec![
+        input.beacon_chain_witness.beacon_lineage[0].clone(),
+        full_intermediate,
+        target,
+    ];
+
+    assert_eq!(
+        process_private_input(
+            &ProofVerifier {
+                accepted: true,
+                calls: Cell::new(0),
+            },
+            &accepting_stateless(),
+            input,
+            &Sha2Hasher,
+        ),
+        Err(Error::NonEmptyIntermediateBlock)
+    );
+}
+
+#[test]
+fn rejects_stateless_output_for_a_different_request() {
+    let (input, _) = base_input();
+    let stateless = StatelessVerifier {
+        successful: true,
+        wrong_root: true,
+        input: RefCell::new(None),
+    };
+
+    assert_eq!(
+        process_private_input(
+            &ProofVerifier {
+                accepted: true,
+                calls: Cell::new(0),
+            },
+            &stateless,
+            input,
+            &Sha2Hasher,
+        ),
+        Err(Error::StatelessRequestRootMismatch)
+    );
+}
+
+#[test]
+fn rejects_progressive_blob_commitments_above_runtime_limit() {
+    let (mut input, _) = base_input();
+    let target = input
+        .beacon_chain_witness
+        .beacon_lineage
+        .last_mut()
+        .unwrap();
+    target.signed_bid.message.blob_kzg_commitments =
+        vec![[5; 48]; MAX_BLOB_COMMITMENTS_PER_BLOCK + 1].into();
+
+    let mut body_root = target.signed_bid.hash_tree_root(&Sha2Hasher);
+    for (level, sibling) in target.signed_bid_merkle_witness.iter().enumerate() {
+        body_root = if ((SIGNED_EXECUTION_PAYLOAD_BID_INDEX >> level) & 1) == 0 {
+            hash_nodes(&Sha2Hasher, &body_root, sibling)
+        } else {
+            hash_nodes(&Sha2Hasher, sibling, &body_root)
+        };
+    }
+    target.header.body_root = body_root;
+    input
+        .beacon_chain_witness
+        .signed_envelope
+        .message
+        .beacon_block_root = target.header.hash_tree_root(&Sha2Hasher);
+
+    assert_eq!(
+        process_private_input(
+            &ProofVerifier {
+                accepted: true,
+                calls: Cell::new(0),
+            },
+            &accepting_stateless(),
+            input,
+            &Sha2Hasher,
+        ),
+        Err(Error::VersionedHashesOverflow)
+    );
+}

--- a/crates/stateless-validator-common/Cargo.toml
+++ b/crates/stateless-validator-common/Cargo.toml
@@ -21,6 +21,9 @@ libssz-derive.workspace = true
 libssz-merkle = { workspace = true, features = ["sha2-backend"] }
 libssz-types.workspace = true
 
+[dev-dependencies]
+hex-literal.workspace = true
+
 [features]
 # guest
 default = ["std"]

--- a/crates/stateless-validator-common/src/guest/error.rs
+++ b/crates/stateless-validator-common/src/guest/error.rs
@@ -28,6 +28,16 @@ pub enum Error {
     /// `InactiveForkConfigError`.
     #[error("ChainConfig active_fork is not active for the target payload")]
     InactiveForkConfig,
+    /// A progressive Gloas list exceeded its consensus runtime limit.
+    #[error("{field} length {length} exceeds runtime maximum {max}")]
+    ProgressiveListTooLong {
+        /// Consensus field name.
+        field: &'static str,
+        /// Decoded list length.
+        length: usize,
+        /// Consensus runtime maximum.
+        max: usize,
+    },
 }
 
 impl From<DecodeError> for Error {

--- a/crates/stateless-validator-common/src/guest/input/new_payload_request.rs
+++ b/crates/stateless-validator-common/src/guest/input/new_payload_request.rs
@@ -15,8 +15,10 @@ use alloc::vec::Vec;
 
 use libssz::{DecodeError, SszDecode, SszEncode};
 use libssz_derive::{HashTreeRoot, SszDecode, SszEncode};
-use libssz_merkle::{HashTreeRoot, Sha256Hasher};
+use libssz_merkle::{HashTreeRoot, Sha256Hasher, mix_in_active_fields};
 use libssz_types::SszList;
+
+use crate::{ProgressiveList, merkleize_progressive};
 
 /// Primitive types from the Amsterdam stateless schema.
 pub type Hash32 = [u8; 32];
@@ -39,9 +41,9 @@ pub const MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD: usize = 16;
 pub const MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD: usize = 2;
 pub const MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD: usize = 64;
 pub const MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD: usize = 16;
+pub const MAX_BLOCK_ACCESS_LIST_BYTES: usize = 1 << 24;
 
-/// Composite types from the Amsterdam stateless schema.
-pub type BlockAccessList = SszList<u8, MAX_BYTES_PER_TRANSACTION>;
+/// Bounded composite types used before Gloas.
 pub type Transaction = SszList<u8, MAX_BYTES_PER_TRANSACTION>;
 pub type Transactions = SszList<Transaction, MAX_TRANSACTIONS_PER_PAYLOAD>;
 pub type Withdrawals = SszList<Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD>;
@@ -53,6 +55,76 @@ pub type ConsolidationRequests =
 pub type BuilderDepositRequests =
     SszList<BuilderDepositRequest, MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD>;
 pub type BuilderExitRequests = SszList<BuilderExitRequest, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD>;
+
+/// Progressive composite types introduced by Gloas/EIP-7688.
+pub type ProgressiveTransaction = ProgressiveList<u8>;
+pub type ProgressiveTransactions = ProgressiveList<ProgressiveTransaction>;
+pub type ProgressiveWithdrawals = ProgressiveList<Withdrawal>;
+pub type BlockAccessList = ProgressiveList<u8>;
+pub type ProgressiveDepositRequests = ProgressiveList<DepositRequest>;
+pub type ProgressiveWithdrawalRequests = ProgressiveList<WithdrawalRequest>;
+pub type ProgressiveConsolidationRequests = ProgressiveList<ConsolidationRequest>;
+pub type ProgressiveBuilderDepositRequests = ProgressiveList<BuilderDepositRequest>;
+pub type ProgressiveBuilderExitRequests = ProgressiveList<BuilderExitRequest>;
+
+/// A borrowed view over bounded pre-Gloas or progressive Gloas transactions.
+#[derive(Debug, Clone, Copy)]
+pub enum TransactionsRef<'a> {
+    Bounded(&'a Transactions),
+    Progressive(&'a ProgressiveTransactions),
+}
+
+impl TransactionsRef<'_> {
+    /// Returns the number of transactions.
+    pub fn len(self) -> usize {
+        match self {
+            Self::Bounded(transactions) => transactions.len(),
+            Self::Progressive(transactions) => transactions.len(),
+        }
+    }
+
+    /// Returns whether there are no transactions.
+    pub fn is_empty(self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a> TransactionsRef<'a> {
+    /// Iterates over transactions as byte slices.
+    pub fn iter(self) -> TransactionsIter<'a> {
+        match self {
+            Self::Bounded(transactions) => TransactionsIter::Bounded(transactions.iter()),
+            Self::Progressive(transactions) => TransactionsIter::Progressive(transactions.iter()),
+        }
+    }
+}
+
+impl<'a> IntoIterator for TransactionsRef<'a> {
+    type Item = &'a [u8];
+    type IntoIter = TransactionsIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over either bounded pre-Gloas or progressive Gloas transactions.
+#[derive(Debug)]
+pub enum TransactionsIter<'a> {
+    Bounded(core::slice::Iter<'a, Transaction>),
+    Progressive(core::slice::Iter<'a, ProgressiveTransaction>),
+}
+
+impl<'a> Iterator for TransactionsIter<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Bounded(iter) => iter.next().map(|transaction| &transaction[..]),
+            Self::Progressive(iter) => iter.next().map(|transaction| &transaction[..]),
+        }
+    }
+}
 
 /// Withdrawals represent a transfer of ETH from the consensus layer (beacon chain) to the
 /// execution layer, as validated by the consensus layer. Each withdrawal is listed in the block's
@@ -123,13 +195,28 @@ pub struct ExecutionRequestsElectraFulu {
 
 /// Typed engine-API container of execution-layer triggered requests, as of Gloas, which
 /// EIP-8282 extends with the builder deposit and builder exit lists.
-#[derive(Debug, Clone, Default, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, SszEncode, SszDecode)]
 pub struct ExecutionRequestsGloas {
-    pub deposits: DepositRequests,
-    pub withdrawals: WithdrawalRequests,
-    pub consolidations: ConsolidationRequests,
-    pub builder_deposits: BuilderDepositRequests,
-    pub builder_exits: BuilderExitRequests,
+    pub deposits: ProgressiveDepositRequests,
+    pub withdrawals: ProgressiveWithdrawalRequests,
+    pub consolidations: ProgressiveConsolidationRequests,
+    pub builder_deposits: ProgressiveBuilderDepositRequests,
+    pub builder_exits: ProgressiveBuilderExitRequests,
+}
+
+impl HashTreeRoot for ExecutionRequestsGloas {
+    fn hash_tree_root(&self, hasher: &impl Sha256Hasher) -> [u8; 32] {
+        progressive_container_root(
+            hasher,
+            &[
+                self.deposits.hash_tree_root(hasher),
+                self.withdrawals.hash_tree_root(hasher),
+                self.consolidations.hash_tree_root(hasher),
+                self.builder_deposits.hash_tree_root(hasher),
+                self.builder_exits.hash_tree_root(hasher),
+            ],
+        )
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
@@ -190,7 +277,7 @@ pub struct ExecutionPayloadV3 {
     pub excess_blob_gas: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, SszEncode, SszDecode)]
 pub struct ExecutionPayloadV4 {
     pub parent_hash: Hash32,
     pub fee_recipient: Address,
@@ -205,12 +292,73 @@ pub struct ExecutionPayloadV4 {
     pub extra_data: ExtraData,
     pub base_fee_per_gas: Uint256Bytes,
     pub block_hash: Hash32,
-    pub transactions: Transactions,
-    pub withdrawals: Withdrawals,
+    pub transactions: ProgressiveTransactions,
+    pub withdrawals: ProgressiveWithdrawals,
     pub blob_gas_used: u64,
     pub excess_blob_gas: u64,
     pub block_access_list: BlockAccessList,
     pub slot_number: u64,
+}
+
+impl Default for ExecutionPayloadV4 {
+    fn default() -> Self {
+        Self {
+            parent_hash: [0; 32],
+            fee_recipient: [0; 20],
+            state_root: [0; 32],
+            receipts_root: [0; 32],
+            logs_bloom: [0; 256],
+            prev_randao: [0; 32],
+            block_number: 0,
+            gas_limit: 0,
+            gas_used: 0,
+            timestamp: 0,
+            extra_data: Default::default(),
+            base_fee_per_gas: [0; 32],
+            block_hash: [0; 32],
+            transactions: Default::default(),
+            withdrawals: Default::default(),
+            blob_gas_used: 0,
+            excess_blob_gas: 0,
+            block_access_list: Default::default(),
+            slot_number: 0,
+        }
+    }
+}
+
+impl HashTreeRoot for ExecutionPayloadV4 {
+    fn hash_tree_root(&self, hasher: &impl Sha256Hasher) -> [u8; 32] {
+        progressive_container_root(
+            hasher,
+            &[
+                self.parent_hash.hash_tree_root(hasher),
+                self.fee_recipient.hash_tree_root(hasher),
+                self.state_root.hash_tree_root(hasher),
+                self.receipts_root.hash_tree_root(hasher),
+                self.logs_bloom.hash_tree_root(hasher),
+                self.prev_randao.hash_tree_root(hasher),
+                self.block_number.hash_tree_root(hasher),
+                self.gas_limit.hash_tree_root(hasher),
+                self.gas_used.hash_tree_root(hasher),
+                self.timestamp.hash_tree_root(hasher),
+                self.extra_data.hash_tree_root(hasher),
+                self.base_fee_per_gas.hash_tree_root(hasher),
+                self.block_hash.hash_tree_root(hasher),
+                self.transactions.hash_tree_root(hasher),
+                self.withdrawals.hash_tree_root(hasher),
+                self.blob_gas_used.hash_tree_root(hasher),
+                self.excess_blob_gas.hash_tree_root(hasher),
+                self.block_access_list.hash_tree_root(hasher),
+                self.slot_number.hash_tree_root(hasher),
+            ],
+        )
+    }
+}
+
+fn progressive_container_root(hasher: &impl Sha256Hasher, field_roots: &[[u8; 32]]) -> [u8; 32] {
+    let root = merkleize_progressive(hasher, field_roots);
+    let active_fields = alloc::vec![true; field_roots.len()];
+    mix_in_active_fields(hasher, &root, &active_fields)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, HashTreeRoot, SszEncode, SszDecode)]
@@ -302,14 +450,93 @@ impl NewPayloadRequest {
     }
 
     /// Returns the transactions of the execution payload.
-    pub fn transactions(&self) -> &Transactions {
+    pub fn transactions(&self) -> TransactionsRef<'_> {
         match self {
-            Self::Bellatrix(request) => &request.execution_payload.transactions,
-            Self::Capella(request) => &request.execution_payload.transactions,
-            Self::Deneb(request) => &request.execution_payload.transactions,
-            Self::ElectraFulu(request) => &request.execution_payload.transactions,
-            Self::Gloas(request) => &request.execution_payload.transactions,
+            Self::Bellatrix(request) => {
+                TransactionsRef::Bounded(&request.execution_payload.transactions)
+            }
+            Self::Capella(request) => {
+                TransactionsRef::Bounded(&request.execution_payload.transactions)
+            }
+            Self::Deneb(request) => {
+                TransactionsRef::Bounded(&request.execution_payload.transactions)
+            }
+            Self::ElectraFulu(request) => {
+                TransactionsRef::Bounded(&request.execution_payload.transactions)
+            }
+            Self::Gloas(request) => {
+                TransactionsRef::Progressive(&request.execution_payload.transactions)
+            }
         }
+    }
+
+    /// Enforces the consensus maxima for Gloas progressive lists at runtime.
+    pub fn validate_progressive_limits(&self) -> Result<(), crate::guest::Error> {
+        let Self::Gloas(request) = self else {
+            return Ok(());
+        };
+        let payload = &request.execution_payload;
+        ensure_runtime_limit(
+            "execution_payload.transactions",
+            payload.transactions.len(),
+            MAX_TRANSACTIONS_PER_PAYLOAD,
+        )?;
+        for transaction in &payload.transactions {
+            ensure_runtime_limit(
+                "execution_payload.transactions[]",
+                transaction.len(),
+                MAX_BYTES_PER_TRANSACTION,
+            )?;
+        }
+        ensure_runtime_limit(
+            "execution_payload.withdrawals",
+            payload.withdrawals.len(),
+            MAX_WITHDRAWALS_PER_PAYLOAD,
+        )?;
+        ensure_runtime_limit(
+            "execution_payload.block_access_list",
+            payload.block_access_list.len(),
+            MAX_BLOCK_ACCESS_LIST_BYTES,
+        )?;
+
+        let requests = &request.execution_requests;
+        ensure_runtime_limit(
+            "execution_requests.deposits",
+            requests.deposits.len(),
+            MAX_DEPOSIT_REQUESTS_PER_PAYLOAD,
+        )?;
+        ensure_runtime_limit(
+            "execution_requests.withdrawals",
+            requests.withdrawals.len(),
+            MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD,
+        )?;
+        ensure_runtime_limit(
+            "execution_requests.consolidations",
+            requests.consolidations.len(),
+            MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD,
+        )?;
+        ensure_runtime_limit(
+            "execution_requests.builder_deposits",
+            requests.builder_deposits.len(),
+            MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD,
+        )?;
+        ensure_runtime_limit(
+            "execution_requests.builder_exits",
+            requests.builder_exits.len(),
+            MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD,
+        )
+    }
+}
+
+fn ensure_runtime_limit(
+    field: &'static str,
+    length: usize,
+    max: usize,
+) -> Result<(), crate::guest::Error> {
+    if length > max {
+        Err(crate::guest::Error::ProgressiveListTooLong { field, length, max })
+    } else {
+        Ok(())
     }
 }
 
@@ -380,6 +607,7 @@ impl SszDecode for NewPayloadRequest {
 mod tests {
     use alloc::vec;
 
+    use hex_literal::hex;
     use libssz_merkle::Sha2Hasher;
 
     use crate::guest::input::{
@@ -474,11 +702,16 @@ mod tests {
             extra_data: v3.extra_data,
             base_fee_per_gas: v3.base_fee_per_gas,
             block_hash: v3.block_hash,
-            transactions: v3.transactions,
-            withdrawals: v3.withdrawals,
+            transactions: v3
+                .transactions
+                .into_iter()
+                .map(|transaction| ProgressiveTransaction::from(transaction.into_inner()))
+                .collect::<Vec<_>>()
+                .into(),
+            withdrawals: v3.withdrawals.into_inner().into(),
             blob_gas_used: v3.blob_gas_used,
             excess_blob_gas: v3.excess_blob_gas,
-            block_access_list: vec![0xba; 33].try_into().unwrap(),
+            block_access_list: vec![0xba; 33].into(),
             slot_number: 42,
         }
     }
@@ -549,11 +782,11 @@ mod tests {
 
     fn execution_requests_gloas() -> ExecutionRequestsGloas {
         ExecutionRequestsGloas {
-            deposits: deposit_requests(),
-            withdrawals: withdrawal_requests(),
-            consolidations: consolidation_requests(),
-            builder_deposits: builder_deposit_requests(),
-            builder_exits: builder_exit_requests(),
+            deposits: deposit_requests().into_inner().into(),
+            withdrawals: withdrawal_requests().into_inner().into(),
+            consolidations: consolidation_requests().into_inner().into(),
+            builder_deposits: builder_deposit_requests().into_inner().into(),
+            builder_exits: builder_exit_requests().into_inner().into(),
         }
     }
 
@@ -645,5 +878,46 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn gloas_progressive_roots_match_lighthouse_unstable() {
+        // Generated with Lighthouse `unstable` at
+        // e6a90c168436d8b8d6b5c779c9b0550bd56fb8c7.
+        assert_eq!(
+            ExecutionPayloadV4::default().hash_tree_root(&Sha2Hasher),
+            hex!("19e3b044dae3657cb2628406b78c61d8796fd490922f17441576a5bfbe8501df")
+        );
+        assert_eq!(
+            ExecutionRequestsGloas::default().hash_tree_root(&Sha2Hasher),
+            hex!("87b69a306c8e430d0857f7c4ac5e27cecffa1108d43c2e5df7388056fea7a423")
+        );
+    }
+
+    #[test]
+    fn rejects_gloas_progressive_list_over_runtime_limit() {
+        let mut request = gloas();
+        let NewPayloadRequest::Gloas(request) = &mut request else {
+            unreachable!();
+        };
+        request.execution_payload.withdrawals = vec![
+            Withdrawal {
+                index: 1,
+                validator_index: 2,
+                address: [3; 20],
+                amount: 4,
+            };
+            MAX_WITHDRAWALS_PER_PAYLOAD + 1
+        ]
+        .into();
+
+        assert!(matches!(
+            NewPayloadRequest::Gloas(request.clone()).validate_progressive_limits(),
+            Err(crate::guest::Error::ProgressiveListTooLong {
+                field: "execution_payload.withdrawals",
+                length,
+                max: MAX_WITHDRAWALS_PER_PAYLOAD,
+            }) if length == MAX_WITHDRAWALS_PER_PAYLOAD + 1
+        ));
     }
 }

--- a/crates/stateless-validator-common/src/lib.rs
+++ b/crates/stateless-validator-common/src/lib.rs
@@ -7,5 +7,7 @@ extern crate alloc;
 pub use libssz::{DecodeError, SszDecode, SszEncode};
 pub use libssz_merkle::{HashTreeRoot, Sha2Hasher, Sha256Hasher};
 pub use libssz_types::{SszList, SszVector};
+pub use progressive_list::{ProgressiveList, merkleize_progressive};
 
 pub mod guest;
+mod progressive_list;

--- a/crates/stateless-validator-common/src/progressive_list.rs
+++ b/crates/stateless-validator-common/src/progressive_list.rs
@@ -1,0 +1,188 @@
+//! Progressive SSZ list support following the current EIP-7916 tree shape.
+//!
+//! The pinned `libssz-types` release implements an earlier draft whose branch
+//! order differs from the current standard and Lighthouse `unstable`.
+
+use alloc::vec::Vec;
+use core::ops::Deref;
+
+use libssz::{DecodeError, SszDecode, SszEncode};
+use libssz_merkle::{HashTreeRoot, Node, Sha256Hasher, hash_nodes, merkleize, mix_in_length, pack};
+
+/// An unbounded SSZ list whose hash-tree root uses progressive merkleization.
+///
+/// Its wire encoding is identical to `Vec<T>`. Consensus maximums that used to
+/// be encoded in bounded list types must be checked separately at runtime.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ProgressiveList<T>(Vec<T>);
+
+impl<T> ProgressiveList<T> {
+    /// Creates an empty progressive list.
+    pub const fn new() -> Self {
+        Self(Vec::new())
+    }
+
+    /// Appends one value.
+    pub fn push(&mut self, value: T) {
+        self.0.push(value);
+    }
+
+    /// Returns the number of values.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Consumes the list and returns its values.
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Default for ProgressiveList<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Deref for ProgressiveList<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> From<Vec<T>> for ProgressiveList<T> {
+    fn from(values: Vec<T>) -> Self {
+        Self(values)
+    }
+}
+
+impl<T> FromIterator<T> for ProgressiveList<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<T> IntoIterator for ProgressiveList<T> {
+    type Item = T;
+    type IntoIter = alloc::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a ProgressiveList<T> {
+    type Item = &'a T;
+    type IntoIter = core::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<T: SszEncode> SszEncode for ProgressiveList<T> {
+    fn is_fixed_size() -> bool {
+        false
+    }
+
+    fn fixed_size() -> usize {
+        0
+    }
+
+    fn encoded_len(&self) -> usize {
+        self.0.encoded_len()
+    }
+
+    fn ssz_append(&self, buffer: &mut Vec<u8>) {
+        self.0.ssz_append(buffer);
+    }
+}
+
+impl<T: SszDecode> SszDecode for ProgressiveList<T> {
+    fn is_fixed_size() -> bool {
+        false
+    }
+
+    fn fixed_size() -> usize {
+        0
+    }
+
+    fn from_ssz_bytes(bytes: &[u8]) -> Result<Self, DecodeError> {
+        Vec::<T>::from_ssz_bytes(bytes).map(Self)
+    }
+}
+
+impl<T: HashTreeRoot + SszEncode> HashTreeRoot for ProgressiveList<T> {
+    fn hash_tree_root(&self, hasher: &impl Sha256Hasher) -> Node {
+        let chunks = if T::is_basic_type() {
+            let mut serialized = Vec::new();
+            for item in &self.0 {
+                item.ssz_append(&mut serialized);
+            }
+            pack(&serialized)
+        } else {
+            self.0
+                .iter()
+                .map(|item| item.hash_tree_root(hasher))
+                .collect()
+        };
+
+        let root = merkleize_progressive(hasher, &chunks);
+        mix_in_length(hasher, &root, self.len())
+    }
+}
+
+/// Merkleizes chunks using the EIP-7916 progressive `1, 4, 16, ...` tree.
+pub fn merkleize_progressive(hasher: &impl Sha256Hasher, chunks: &[Node]) -> Node {
+    merkleize_progressive_inner(hasher, chunks, 1)
+}
+
+fn merkleize_progressive_inner(
+    hasher: &impl Sha256Hasher,
+    chunks: &[Node],
+    num_leaves: usize,
+) -> Node {
+    if chunks.is_empty() {
+        return [0; 32];
+    }
+
+    let take = core::cmp::min(num_leaves, chunks.len());
+    let subtree = merkleize(hasher, &chunks[..take], Some(num_leaves));
+    let remainder =
+        merkleize_progressive_inner(hasher, &chunks[take..], num_leaves.saturating_mul(4));
+    hash_nodes(hasher, &subtree, &remainder)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use hex_literal::hex;
+    use libssz::{SszDecode, SszEncode};
+    use libssz_merkle::{HashTreeRoot, Sha2Hasher};
+
+    use super::ProgressiveList;
+
+    #[test]
+    fn nonempty_basic_list_matches_lighthouse_unstable() {
+        // Generated with Lighthouse `unstable` at
+        // e6a90c168436d8b8d6b5c779c9b0550bd56fb8c7.
+        let list = ProgressiveList::from((0_u8..96).collect::<Vec<_>>());
+
+        assert_eq!(
+            list.hash_tree_root(&Sha2Hasher),
+            hex!("a812257f8075af058ebaa831c2c1361660131a647866c3d0ca56af0df68fb896")
+        );
+        assert_eq!(
+            ProgressiveList::<u8>::from_ssz_bytes(&list.to_ssz()).unwrap(),
+            list
+        );
+    }
+}

--- a/crates/stateless-validator-ethrex/Cargo.toml
+++ b/crates/stateless-validator-ethrex/Cargo.toml
@@ -24,6 +24,7 @@ zkvm-interface = { workspace = true, optional = true }
 ere-platform-core.workspace = true
 
 # local
+recursive-execution-proof.workspace = true
 stateless-validator-common.workspace = true
 
 [dev-dependencies]
@@ -38,7 +39,7 @@ required-features = ["host"]
 [features]
 # guest
 default = ["std"]
-std = ["stateless-validator-common/std"]
+std = ["recursive-execution-proof/std", "stateless-validator-common/std"]
 openvm = ["zkvm-interface"]
 sp1 = ["zkvm-interface"]
 zisk = ["zkvm-interface"]

--- a/crates/stateless-validator-ethrex/src/guest.rs
+++ b/crates/stateless-validator-ethrex/src/guest.rs
@@ -1,11 +1,15 @@
 //! Ethrex stateless validator guest program.
 
 use alloc::{format, vec::Vec};
+use core::marker::PhantomData;
 
 pub use ere_platform_core::Platform;
 use ethrex_guest_program::{
     common::ExecutionError,
     l1::{DecodedEip8025, validate_eip8025_canonical_execution, validate_eip8025_execution},
+};
+use recursive_execution_proof::{
+    ExecutionProofVerifier, PrivateInput, PublicInput, StatelessNewPayloadVerifier,
 };
 use stateless_validator_common::{
     HashTreeRoot, SszEncode as _,
@@ -36,20 +40,51 @@ pub fn run_stateless_guest<P: Platform>(input_bytes: &[u8]) -> Vec<u8> {
         return StatelessValidationResult::default().to_ssz();
     };
 
+    let output = validate_stateless_input::<P>(fork, input);
+
+    P::cycle_scope("serialize_output", || output.to_ssz())
+}
+
+/// Runs one recursive EIP-8025 step using Ethrex for the stateless transition.
+///
+/// `proof_verifier` is proof-system specific and must bind the prior proof's
+/// `proof_type` to this exact guest program. Bid and envelope BLS signatures
+/// remain consensus-client checks, matching the specification's current
+/// signature boundary.
+pub fn process_recursive_input<P: Platform>(
+    input: PrivateInput,
+    proof_verifier: &impl ExecutionProofVerifier,
+) -> Result<PublicInput, recursive_execution_proof::Error> {
+    recursive_execution_proof::process_private_input(
+        proof_verifier,
+        &EthrexStatelessVerifier::<P>(PhantomData),
+        input,
+        &sha256_hasher(),
+    )
+}
+
+struct EthrexStatelessVerifier<P>(PhantomData<fn() -> P>);
+
+impl<P: Platform> StatelessNewPayloadVerifier for EthrexStatelessVerifier<P> {
+    fn verify_stateless_new_payload(&self, input: StatelessInput) -> StatelessValidationResult {
+        validate_stateless_input::<P>(ProtocolFork::Amsterdam, input)
+    }
+}
+
+fn validate_stateless_input<P: Platform>(
+    fork: ProtocolFork,
+    input: StatelessInput,
+) -> StatelessValidationResult {
     let new_payload_request_root = P::cycle_scope("new_payload_request_root", || {
         input.new_payload_request.hash_tree_root(&sha256_hasher())
     });
     let chain_config = input.chain_config.clone();
-
     let successful_validation = verify_stateless_new_payload::<P>(fork, input).is_ok();
-
-    let output = StatelessValidationResult::new(
+    StatelessValidationResult::new(
         new_payload_request_root,
         successful_validation,
         chain_config,
-    );
-
-    P::cycle_scope("serialize_output", || output.to_ssz())
+    )
 }
 
 /// Statelessly validates the execution payload, mirroring
@@ -58,12 +93,12 @@ fn verify_stateless_new_payload<P: Platform>(
     fork: ProtocolFork,
     input: StatelessInput,
 ) -> Result<(), Error> {
+    P::cycle_scope("validate_progressive_limits", || {
+        input.new_payload_request.validate_progressive_limits()
+    })?;
     P::cycle_scope("validate_chain_config", || {
         input.chain_config.validate(&input.new_payload_request)
     })?;
-
-    #[cfg(debug_assertions)]
-    let new_payload_request_root = input.new_payload_request.hash_tree_root(&sha256_hasher());
 
     let ethrex_input = P::cycle_scope("to_ethrex_input", || {
         to_ethrex_input(fork, input).map_err(|err| {
@@ -71,12 +106,6 @@ fn verify_stateless_new_payload<P: Platform>(
             err
         })
     })?;
-
-    #[cfg(debug_assertions)]
-    if fork == ProtocolFork::Amsterdam {
-        let ethrex_new_payload_request_root = ethrex_new_payload_request_root(&ethrex_input);
-        assert_eq!(ethrex_new_payload_request_root, new_payload_request_root);
-    }
 
     P::cycle_scope("run_validation", || {
         run_validation(ethrex_input).map_err(|err| {
@@ -100,19 +129,5 @@ fn run_validation(ethrex_input: DecodedEip8025) -> Result<(), ExecutionError> {
             stateless_input,
             chain_config,
         } => validate_eip8025_canonical_execution(stateless_input, chain_config, crypto::crypto()),
-    }
-}
-
-#[cfg(debug_assertions)]
-fn ethrex_new_payload_request_root(ethrex_input: &DecodedEip8025) -> [u8; 32] {
-    let hasher = sha256_hasher();
-    match ethrex_input {
-        DecodedEip8025::Legacy {
-            new_payload_request,
-            ..
-        } => new_payload_request.hash_tree_root(&hasher),
-        DecodedEip8025::Canonical {
-            stateless_input, ..
-        } => stateless_input.new_payload_request.hash_tree_root(&hasher),
     }
 }

--- a/crates/stateless-validator-ethrex/src/guest/convert.rs
+++ b/crates/stateless-validator-ethrex/src/guest/convert.rs
@@ -20,14 +20,18 @@ use ethrex_guest_program::l1::{
 };
 use hex_literal::hex;
 use stateless_validator_common::{
-    SszList, SszVector,
+    ProgressiveList, SszList, SszVector,
     guest::{
         Error as CommonError,
         input::{
             ChainConfig, ExecutionWitness, ProtocolFork, StatelessInput,
             new_payload_request::{
-                ExecutionRequestsGloas, MAX_WITHDRAWALS_PER_PAYLOAD, NewPayloadRequest,
-                NewPayloadRequestElectraFulu, NewPayloadRequestGloas, Withdrawals,
+                ExecutionRequestsGloas, MAX_BLOCK_ACCESS_LIST_BYTES,
+                MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD, MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD,
+                MAX_BYTES_PER_TRANSACTION, MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD,
+                MAX_DEPOSIT_REQUESTS_PER_PAYLOAD, MAX_TRANSACTIONS_PER_PAYLOAD,
+                MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD, MAX_WITHDRAWALS_PER_PAYLOAD,
+                NewPayloadRequest, NewPayloadRequestElectraFulu, NewPayloadRequestGloas,
             },
         },
     },
@@ -48,7 +52,7 @@ pub(crate) fn to_ethrex_input(
     Ok(match input.new_payload_request {
         NewPayloadRequest::Gloas(request) => DecodedEip8025::Canonical {
             stateless_input: CanonicalStatelessInput {
-                new_payload_request: to_ethrex_new_payload_request(request),
+                new_payload_request: to_ethrex_new_payload_request(request)?,
                 witness: to_ethrex_witness(input.witness),
                 chain_config: to_ethrex_canonical_chain_config(&input.chain_config),
                 public_keys: map_ssz_list(input.public_keys, array_to_ssz_vec),
@@ -74,8 +78,27 @@ pub(crate) fn to_ethrex_input(
 /// Converts the new payload request into the ethrex container.
 fn to_ethrex_new_payload_request(
     request: NewPayloadRequestGloas,
-) -> eip8025_ssz::NewPayloadRequestAmsterdam {
+) -> Result<eip8025_ssz::NewPayloadRequestAmsterdam, Error> {
     let payload = request.execution_payload;
+    let transactions_length = payload.transactions.len();
+    let transactions = payload
+        .transactions
+        .into_iter()
+        .map(|transaction| {
+            progressive_to_ssz_list(
+                "execution_payload.transactions[]",
+                transaction,
+                MAX_BYTES_PER_TRANSACTION,
+                core::convert::identity,
+            )
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    let transactions =
+        SszList::try_from(transactions).map_err(|_| CommonError::ProgressiveListTooLong {
+            field: "execution_payload.transactions",
+            length: transactions_length,
+            max: MAX_TRANSACTIONS_PER_PAYLOAD,
+        })?;
     let execution_payload = eip8025_ssz::ExecutionPayloadV4 {
         parent_hash: payload.parent_hash,
         fee_recipient: payload.fee_recipient.into(),
@@ -90,74 +113,115 @@ fn to_ethrex_new_payload_request(
         extra_data: payload.extra_data,
         base_fee_per_gas: payload.base_fee_per_gas,
         block_hash: payload.block_hash,
-        transactions: payload.transactions,
-        withdrawals: to_ethrex_withdrawals(payload.withdrawals),
+        transactions,
+        withdrawals: to_ethrex_withdrawals(payload.withdrawals)?,
         blob_gas_used: payload.blob_gas_used,
         excess_blob_gas: payload.excess_blob_gas,
-        block_access_list: payload.block_access_list,
+        block_access_list: progressive_to_ssz_list(
+            "execution_payload.block_access_list",
+            payload.block_access_list,
+            MAX_BLOCK_ACCESS_LIST_BYTES,
+            core::convert::identity,
+        )?,
         slot_number: payload.slot_number,
     };
-    eip8025_ssz::NewPayloadRequestAmsterdam {
+    Ok(eip8025_ssz::NewPayloadRequestAmsterdam {
         execution_payload,
         versioned_hashes: request.versioned_hashes,
         parent_beacon_block_root: request.parent_beacon_block_root,
-        execution_requests: to_ethrex_execution_requests(request.execution_requests),
-    }
+        execution_requests: to_ethrex_execution_requests(request.execution_requests)?,
+    })
 }
 
 /// Converts canonical withdrawals into the ethrex list.
 fn to_ethrex_withdrawals(
-    withdrawals: Withdrawals,
-) -> SszList<eip8025_ssz::Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD> {
-    map_ssz_list(withdrawals, |withdrawal| eip8025_ssz::Withdrawal {
-        index: withdrawal.index,
-        validator_index: withdrawal.validator_index,
-        address: withdrawal.address.into(),
-        amount: withdrawal.amount,
-    })
+    withdrawals: ProgressiveList<
+        stateless_validator_common::guest::input::new_payload_request::Withdrawal,
+    >,
+) -> Result<SszList<eip8025_ssz::Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD>, Error> {
+    progressive_to_ssz_list(
+        "execution_payload.withdrawals",
+        withdrawals,
+        MAX_WITHDRAWALS_PER_PAYLOAD,
+        |withdrawal| eip8025_ssz::Withdrawal {
+            index: withdrawal.index,
+            validator_index: withdrawal.validator_index,
+            address: withdrawal.address.into(),
+            amount: withdrawal.amount,
+        },
+    )
 }
 
 /// Converts the canonical execution requests into the ethrex container.
 fn to_ethrex_execution_requests(
     requests: ExecutionRequestsGloas,
-) -> eip8025_ssz::ExecutionRequests {
-    eip8025_ssz::ExecutionRequests {
-        deposits: map_ssz_list(requests.deposits, |deposit| eip8025_ssz::DepositRequest {
-            pubkey: deposit.pubkey,
-            withdrawal_credentials: deposit.withdrawal_credentials,
-            amount: deposit.amount,
-            signature: deposit.signature,
-            index: deposit.index,
-        }),
-        withdrawals: map_ssz_list(requests.withdrawals, |withdrawal| {
-            eip8025_ssz::WithdrawalRequest {
+) -> Result<eip8025_ssz::ExecutionRequests, Error> {
+    Ok(eip8025_ssz::ExecutionRequests {
+        deposits: progressive_to_ssz_list(
+            "execution_requests.deposits",
+            requests.deposits,
+            MAX_DEPOSIT_REQUESTS_PER_PAYLOAD,
+            |deposit| eip8025_ssz::DepositRequest {
+                pubkey: deposit.pubkey,
+                withdrawal_credentials: deposit.withdrawal_credentials,
+                amount: deposit.amount,
+                signature: deposit.signature,
+                index: deposit.index,
+            },
+        )?,
+        withdrawals: progressive_to_ssz_list(
+            "execution_requests.withdrawals",
+            requests.withdrawals,
+            MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD,
+            |withdrawal| eip8025_ssz::WithdrawalRequest {
                 source_address: withdrawal.source_address.into(),
                 validator_pubkey: withdrawal.validator_pubkey,
                 amount: withdrawal.amount,
-            }
-        }),
-        consolidations: map_ssz_list(requests.consolidations, |consolidation| {
-            eip8025_ssz::ConsolidationRequest {
+            },
+        )?,
+        consolidations: progressive_to_ssz_list(
+            "execution_requests.consolidations",
+            requests.consolidations,
+            MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD,
+            |consolidation| eip8025_ssz::ConsolidationRequest {
                 source_address: consolidation.source_address.into(),
                 source_pubkey: consolidation.source_pubkey,
                 target_pubkey: consolidation.target_pubkey,
-            }
-        }),
-        builder_deposits: map_ssz_list(requests.builder_deposits, |builder_deposit| {
-            eip8025_ssz::BuilderDepositRequest {
+            },
+        )?,
+        builder_deposits: progressive_to_ssz_list(
+            "execution_requests.builder_deposits",
+            requests.builder_deposits,
+            MAX_BUILDER_DEPOSIT_REQUESTS_PER_PAYLOAD,
+            |builder_deposit| eip8025_ssz::BuilderDepositRequest {
                 pubkey: builder_deposit.pubkey,
                 withdrawal_credentials: builder_deposit.withdrawal_credentials,
                 amount: builder_deposit.amount,
                 signature: builder_deposit.signature,
-            }
-        }),
-        builder_exits: map_ssz_list(requests.builder_exits, |builder_exit| {
-            eip8025_ssz::BuilderExitRequest {
+            },
+        )?,
+        builder_exits: progressive_to_ssz_list(
+            "execution_requests.builder_exits",
+            requests.builder_exits,
+            MAX_BUILDER_EXIT_REQUESTS_PER_PAYLOAD,
+            |builder_exit| eip8025_ssz::BuilderExitRequest {
                 source_address: builder_exit.source_address.into(),
                 pubkey: builder_exit.pubkey,
-            }
-        }),
-    }
+            },
+        )?,
+    })
+}
+
+fn progressive_to_ssz_list<T, U, const N: usize>(
+    field: &'static str,
+    values: ProgressiveList<T>,
+    max: usize,
+    mut map: impl FnMut(T) -> U,
+) -> Result<SszList<U, N>, Error> {
+    let length = values.len();
+    let values = values.into_iter().map(&mut map).collect::<Vec<_>>();
+    SszList::try_from(values)
+        .map_err(|_| CommonError::ProgressiveListTooLong { field, length, max }.into())
 }
 
 /// Converts the execution witness into the ethrex container.
@@ -310,18 +374,28 @@ fn to_ethrex_legacy_new_payload_request(
             base_fee_per_gas: payload.base_fee_per_gas,
             block_hash: payload.block_hash,
             transactions: payload.transactions,
-            withdrawals: to_ethrex_withdrawals(payload.withdrawals),
+            withdrawals: map_ssz_list(payload.withdrawals, |withdrawal| eip8025_ssz::Withdrawal {
+                index: withdrawal.index,
+                validator_index: withdrawal.validator_index,
+                address: withdrawal.address.into(),
+                amount: withdrawal.amount,
+            }),
             blob_gas_used: payload.blob_gas_used,
             excess_blob_gas: payload.excess_blob_gas,
         },
         versioned_hashes: request.versioned_hashes,
         parent_beacon_block_root: request.parent_beacon_block_root,
         execution_requests: to_ethrex_execution_requests(ExecutionRequestsGloas {
-            deposits: request.execution_requests.deposits,
-            withdrawals: request.execution_requests.withdrawals,
-            consolidations: request.execution_requests.consolidations,
+            deposits: request.execution_requests.deposits.into_inner().into(),
+            withdrawals: request.execution_requests.withdrawals.into_inner().into(),
+            consolidations: request
+                .execution_requests
+                .consolidations
+                .into_inner()
+                .into(),
             ..Default::default()
-        }),
+        })
+        .expect("bounded Electra/Fulu requests fit their Gloas runtime limits"),
     }
 }
 

--- a/crates/stateless-validator-ethrex/tests/host_execution.rs
+++ b/crates/stateless-validator-ethrex/tests/host_execution.rs
@@ -1,6 +1,10 @@
 //! Execution tests for `stateless-validator-ethrex` guest program on host
 
-use stateless_validator_test::declare_test_host_execution;
+use stateless_validator_test::{
+    declare_test_host_execution, declare_test_host_recursive_execution,
+};
+
+declare_test_host_recursive_execution!(Ethrex);
 
 declare_test_host_execution!(Ethrex, RpcBpo2);
 declare_test_host_execution!(Ethrex, RpcGlamsterdamDevnet7);

--- a/crates/stateless-validator-reth/Cargo.toml
+++ b/crates/stateless-validator-reth/Cargo.toml
@@ -38,6 +38,7 @@ zkvm-interface = { workspace = true, optional = true }
 ere-platform-core.workspace = true
 
 # local
+recursive-execution-proof.workspace = true
 stateless-validator-common.workspace = true
 
 [dev-dependencies]
@@ -52,7 +53,7 @@ required-features = ["host"]
 [features]
 # guest
 default = ["std"]
-std = ["once_cell/std", "stateless-validator-common/std"]
+std = ["once_cell/std", "recursive-execution-proof/std", "stateless-validator-common/std"]
 openvm = ["zkvm-interface"]
 sp1 = ["zkvm-interface"]
 zisk = ["zkvm-interface"]

--- a/crates/stateless-validator-reth/src/guest.rs
+++ b/crates/stateless-validator-reth/src/guest.rs
@@ -1,8 +1,12 @@
 //! Reth stateless validator guest program.
 
 use alloc::{format, vec::Vec};
+use core::marker::PhantomData;
 
 pub use ere_platform_core::Platform;
+use recursive_execution_proof::{
+    ExecutionProofVerifier, PrivateInput, PublicInput, StatelessNewPayloadVerifier,
+};
 use reth_stateless::{stateless_validation_with_trie, validation::StatelessValidationError};
 use reth_tries::zeth::SparseState;
 use stateless_validator_common::{
@@ -37,20 +41,51 @@ pub fn run_stateless_guest<P: Platform>(input_bytes: &[u8]) -> Vec<u8> {
         return StatelessValidationResult::default().to_ssz();
     };
 
+    let output = validate_stateless_input::<P>(fork, input);
+
+    P::cycle_scope("serialize_output", || output.to_ssz())
+}
+
+/// Runs one recursive EIP-8025 step using Reth for the stateless transition.
+///
+/// `proof_verifier` is proof-system specific and must bind the prior proof's
+/// `proof_type` to this exact guest program. Bid and envelope BLS signatures
+/// remain consensus-client checks, matching the specification's current
+/// signature boundary.
+pub fn process_recursive_input<P: Platform>(
+    input: PrivateInput,
+    proof_verifier: &impl ExecutionProofVerifier,
+) -> Result<PublicInput, recursive_execution_proof::Error> {
+    recursive_execution_proof::process_private_input(
+        proof_verifier,
+        &RethStatelessVerifier::<P>(PhantomData),
+        input,
+        &sha256_hasher(),
+    )
+}
+
+struct RethStatelessVerifier<P>(PhantomData<fn() -> P>);
+
+impl<P: Platform> StatelessNewPayloadVerifier for RethStatelessVerifier<P> {
+    fn verify_stateless_new_payload(&self, input: StatelessInput) -> StatelessValidationResult {
+        validate_stateless_input::<P>(ProtocolFork::Amsterdam, input)
+    }
+}
+
+fn validate_stateless_input<P: Platform>(
+    fork: ProtocolFork,
+    input: StatelessInput,
+) -> StatelessValidationResult {
     let new_payload_request_root = P::cycle_scope("new_payload_request_root", || {
         input.new_payload_request.hash_tree_root(&sha256_hasher())
     });
     let chain_config = input.chain_config.clone();
-
     let successful_validation = verify_stateless_new_payload::<P>(fork, input).is_ok();
-
-    let output = StatelessValidationResult::new(
+    StatelessValidationResult::new(
         new_payload_request_root,
         successful_validation,
         chain_config,
-    );
-
-    P::cycle_scope("serialize_output", || output.to_ssz())
+    )
 }
 
 /// Statelessly validates the execution payload, mirroring
@@ -59,6 +94,9 @@ fn verify_stateless_new_payload<P: Platform>(
     fork: ProtocolFork,
     input: StatelessInput,
 ) -> Result<(), Error> {
+    P::cycle_scope("validate_progressive_limits", || {
+        input.new_payload_request.validate_progressive_limits()
+    })?;
     P::cycle_scope("validate_chain_config", || {
         input.chain_config.validate(&input.new_payload_request)
     })?;

--- a/crates/stateless-validator-reth/src/guest/convert.rs
+++ b/crates/stateless-validator-reth/src/guest/convert.rs
@@ -28,7 +28,7 @@ use stateless_validator_common::{
             new_payload_request::{
                 ExecutionPayloadV1, ExecutionPayloadV2, ExecutionPayloadV3, ExecutionPayloadV4,
                 ExecutionRequestsElectraFulu, ExecutionRequestsGloas, Hash32, NewPayloadRequest,
-                VersionedHashes, Withdrawals,
+                VersionedHashes, Withdrawal,
             },
         },
     },
@@ -282,7 +282,9 @@ fn to_alloy_payload_v4(payload: ExecutionPayloadV4) -> alloy_rpc_types_engine::E
 
 /// Converts canonical withdrawals into the alloy list. The list bound matches
 /// the canonical bound.
-fn to_alloy_withdrawals(withdrawals: Withdrawals) -> Vec<alloy_eips::eip4895::Withdrawal> {
+fn to_alloy_withdrawals(
+    withdrawals: impl IntoIterator<Item = Withdrawal>,
+) -> Vec<alloy_eips::eip4895::Withdrawal> {
     withdrawals
         .into_iter()
         .map(|withdrawal| alloy_eips::eip4895::Withdrawal {

--- a/crates/stateless-validator-reth/tests/host_execution.rs
+++ b/crates/stateless-validator-reth/tests/host_execution.rs
@@ -1,6 +1,10 @@
 //! Execution tests for `stateless-validator-reth` guest program on host
 
-use stateless_validator_test::declare_test_host_execution;
+use stateless_validator_test::{
+    declare_test_host_execution, declare_test_host_recursive_execution,
+};
+
+declare_test_host_recursive_execution!(Reth);
 
 declare_test_host_execution!(Reth, RpcBpo2);
 // NOTE:

--- a/crates/stateless-validator-test/Cargo.toml
+++ b/crates/stateless-validator-test/Cargo.toml
@@ -34,10 +34,14 @@ ere-dockerized.workspace = true
 ere-platform-core.workspace = true
 
 # local
+recursive-execution-proof.workspace = true
 stateless-validator-catalog.workspace = true
 stateless-validator-common = { workspace = true, features = ["host"] }
 stateless-validator-ethrex = { workspace = true, features = ["host"] }
 stateless-validator-reth = { workspace = true, features = ["host"] }
+
+# ssz
+libssz-merkle.workspace = true
 
 [dev-dependencies]
 paste.workspace = true

--- a/crates/stateless-validator-test/src/execution/host.rs
+++ b/crates/stateless-validator-test/src/execution/host.rs
@@ -3,7 +3,19 @@
 use std::io::{self, Write};
 
 use ere_platform_core::Platform;
+use libssz_merkle::hash_nodes;
+use recursive_execution_proof::{
+    BeaconBlockBidWitness, BeaconBlockHeader, BeaconChainWitness, Error, ExecutionCheckpoint,
+    ExecutionPayloadBid, ExecutionPayloadEnvelope, ExecutionProof, ExecutionProofVerifier,
+    PrivateInput, SIGNED_EXECUTION_PAYLOAD_BID_INDEX, SignedExecutionPayloadBid,
+    SignedExecutionPayloadEnvelope,
+};
 use stateless_validator_catalog::StatelessValidatorKind;
+use stateless_validator_common::guest::input::{
+    ChainConfig, ExecutionWitness, ForkActivation, ForkConfig,
+    new_payload_request::{ExecutionPayloadV4, ExecutionRequestsGloas},
+};
+use stateless_validator_common::{HashTreeRoot, Sha2Hasher, SszList};
 
 use crate::{
     execution::{ExecutionFailure, ExecutionFailures, run_execution},
@@ -68,6 +80,157 @@ pub fn test_host_execution(
     );
 }
 
+/// Exercises a client's recursive adapter through the native stateless executor.
+///
+/// The synthetic payload is deliberately not executable. All consensus bindings
+/// are valid, so the expected stateless rejection proves that the client adapter
+/// reached its existing execution-validation path.
+pub fn test_host_recursive_execution(stateless_validator_kind: StatelessValidatorKind) {
+    let input = synthetic_recursive_input();
+    let result = match stateless_validator_kind {
+        StatelessValidatorKind::Ethrex => {
+            stateless_validator_ethrex::guest::process_recursive_input::<HostPlatform>(
+                input,
+                &AcceptProof,
+            )
+        }
+        StatelessValidatorKind::Reth => stateless_validator_reth::guest::process_recursive_input::<
+            HostPlatform,
+        >(input, &AcceptProof),
+        StatelessValidatorKind::Zesu => {
+            panic!("host execution is not supported for the zesu guest")
+        }
+    };
+    assert_eq!(result, Err(Error::StatelessValidationFailed));
+}
+
+#[derive(Debug)]
+struct AcceptProof;
+
+impl ExecutionProofVerifier for AcceptProof {
+    fn verify_execution_proof(&self, _proof: &ExecutionProof) -> bool {
+        true
+    }
+}
+
+fn synthetic_recursive_input() -> PrivateInput {
+    let requests = ExecutionRequestsGloas::default();
+    let checkpoint_bid = synthetic_bid([6; 32], [7; 32], [9; 32], 10, &requests);
+    let checkpoint = synthetic_bid_witness(10, [7; 32], checkpoint_bid, 10);
+    let checkpoint_root = checkpoint.header.hash_tree_root(&Sha2Hasher);
+    let origin = ExecutionCheckpoint {
+        slot: 10,
+        beacon_block_root: checkpoint_root,
+    };
+
+    let payload = ExecutionPayloadV4 {
+        parent_hash: [9; 32],
+        fee_recipient: [0; 20],
+        state_root: [1; 32],
+        receipts_root: [2; 32],
+        logs_bloom: [0; 256],
+        prev_randao: [3; 32],
+        block_number: 1,
+        gas_limit: 30_000_000,
+        gas_used: 21_000,
+        timestamp: 1,
+        extra_data: SszList::default(),
+        base_fee_per_gas: [4; 32],
+        block_hash: [11; 32],
+        transactions: Default::default(),
+        withdrawals: Default::default(),
+        blob_gas_used: 0,
+        excess_blob_gas: 0,
+        block_access_list: Default::default(),
+        slot_number: 12,
+    };
+    let target_bid = synthetic_bid([9; 32], checkpoint_root, [11; 32], 12, &requests);
+    let target = synthetic_bid_witness(12, checkpoint_root, target_bid, 20);
+    let target_root = target.header.hash_tree_root(&Sha2Hasher);
+
+    PrivateInput {
+        beacon_chain_witness: BeaconChainWitness {
+            origin: Some(origin),
+            previous_proof: None,
+            beacon_lineage: vec![checkpoint, target],
+            signed_envelope: SignedExecutionPayloadEnvelope {
+                message: ExecutionPayloadEnvelope {
+                    payload,
+                    execution_requests: requests,
+                    builder_index: 42,
+                    beacon_block_root: target_root,
+                    parent_beacon_block_root: checkpoint_root,
+                },
+                signature: [0; 96],
+            },
+        },
+        execution_witness: ExecutionWitness::default(),
+        chain_config: ChainConfig {
+            chain_id: 1,
+            active_fork: ForkConfig::new(ForkActivation::new(Some(0), None)),
+        },
+        public_keys: SszList::default(),
+    }
+}
+
+fn synthetic_bid(
+    parent_block_hash: [u8; 32],
+    parent_block_root: [u8; 32],
+    block_hash: [u8; 32],
+    slot: u64,
+    requests: &ExecutionRequestsGloas,
+) -> ExecutionPayloadBid {
+    ExecutionPayloadBid {
+        parent_block_hash,
+        parent_block_root,
+        block_hash,
+        prev_randao: [3; 32],
+        fee_recipient: [0; 20],
+        gas_limit: 30_000_000,
+        builder_index: 42,
+        slot,
+        value: 0,
+        execution_payment: 0,
+        blob_kzg_commitments: Default::default(),
+        execution_requests_root: recursive_execution_proof::execution_requests_root(
+            requests,
+            &Sha2Hasher,
+        ),
+    }
+}
+
+fn synthetic_bid_witness(
+    slot: u64,
+    parent_root: [u8; 32],
+    bid: ExecutionPayloadBid,
+    branch_byte: u8,
+) -> BeaconBlockBidWitness {
+    let signed_bid = SignedExecutionPayloadBid {
+        message: bid,
+        signature: [0; 96],
+    };
+    let branch = core::array::from_fn(|level| [branch_byte.wrapping_add(level as u8); 32]);
+    let mut body_root = signed_bid.hash_tree_root(&Sha2Hasher);
+    for (level, sibling) in branch.iter().enumerate() {
+        body_root = if ((SIGNED_EXECUTION_PAYLOAD_BID_INDEX >> level) & 1) == 0 {
+            hash_nodes(&Sha2Hasher, &body_root, sibling)
+        } else {
+            hash_nodes(&Sha2Hasher, sibling, &body_root)
+        };
+    }
+    BeaconBlockBidWitness {
+        header: BeaconBlockHeader {
+            slot,
+            proposer_index: 1,
+            parent_root,
+            state_root: [8; 32],
+            body_root,
+        },
+        signed_bid,
+        signed_bid_merkle_witness: branch,
+    }
+}
+
 /// Declares a host execution test for a guest kind and fixture preset.
 #[macro_export]
 macro_rules! declare_test_host_execution {
@@ -85,5 +248,20 @@ macro_rules! declare_test_host_execution {
     };
     ($kind:ident, $preset:ident) => {
         $crate::declare_test_host_execution!($kind, $preset, failures = 0);
+    };
+}
+
+/// Declares a focused host-side recursive adapter test for a guest kind.
+#[macro_export]
+macro_rules! declare_test_host_recursive_execution {
+    ($kind:ident) => {
+        paste::paste! {
+            #[test]
+            fn [<test_host_recursive_execution_ $kind:snake>]() {
+                $crate::execution::host::test_host_recursive_execution(
+                    $crate::StatelessValidatorKind::$kind,
+                );
+            }
+        }
     };
 }


### PR DESCRIPTION
## Summary

- add a shared recursive execution-proof guest crate and canonical recursive input/state types
- align Gloas new-payload request structures with Lighthouse progressive SSZ commitments
- integrate the recursive adapter with both the Reth and Ethrex stateless validator paths
- add focused invariant, failure-path, and native client-adapter coverage

## Testing

- `cargo test -p recursive-execution-proof --offline`
- `cargo test -p stateless-validator-reth --test host_execution --features host --offline`
- `cargo test -p stateless-validator-ethrex --test host_execution --features host --offline`

## Deferred boundaries

- prior-proof verification remains proof-system specific through `ExecutionProofVerifier`
- bid and envelope BLS signature verification remains at the consensus-client boundary
